### PR TITLE
更新 0019.删除链表的倒数第N个节点 go版本

### DIFF
--- a/problems/0019.删除链表的倒数第N个节点.md
+++ b/problems/0019.删除链表的倒数第N个节点.md
@@ -114,24 +114,28 @@ class Solution {
 ```
 Go:
 ```Go
+/**
+ * Definition for singly-linked list.
+ * type ListNode struct {
+ *     Val int
+ *     Next *ListNode
+ * }
+ */
 func removeNthFromEnd(head *ListNode, n int) *ListNode {
-    result:=&ListNode{}
-    result.Next=head
-    var pre *ListNode
-    cur:=result
-
-    i:=1
-    for head!=nil{
-        if i>=n{
-            pre=cur
-            cur=cur.Next
+    dummyHead := &ListNode{}
+    dummyHead.Next = head
+    cur := head
+    prev := dummyHead
+    i := 1
+    for cur != nil {
+        cur = cur.Next
+        if i > n {
+            prev = prev.Next
         }
-        head=head.Next
         i++
     }
-    pre.Next=pre.Next.Next
-    return result.Next
-
+    prev.Next = prev.Next.Next
+    return dummyHead.Next
 }
 ```
 

--- a/problems/0024.两两交换链表中的节点.md
+++ b/problems/0024.两两交换链表中的节点.md
@@ -153,6 +153,19 @@ func swapPairs(head *ListNode) *ListNode {
 }
 ```
 
+```go
+// 递归版本
+func swapPairs(head *ListNode) *ListNode {
+    if head == nil || head.Next == nil {
+        return head
+    }
+    next := head.Next
+    head.Next = swapPairs(next.Next)
+    next.Next = head
+    return next
+}
+```
+
 Javascript:
 ```javascript
 var swapPairs = function (head) {


### PR DESCRIPTION
1、将原先代码中每次都需要获取慢指针前一个元素的方式修改成直接用慢指针进行元素的删除（代码便于理解）
2、调整代码格式