### PR TITLE
增加 673.最长递增子序列的个数 的 Java, Python, Go语言实现

### DIFF
--- a/problems/0673.最长递增子序列的个数.md
+++ b/problems/0673.最长递增子序列的个数.md
@@ -9,6 +9,10 @@
 
 # 673.最长递增子序列的个数
 
+
+[力扣题目链接](https://leetcode-cn.com/problems/number-of-longest-increasing-subsequence/)
+
+
 给定一个未排序的整数数组，找到最长递增子序列的个数。
 
 示例 1:
@@ -224,16 +228,110 @@ public:
 ## Java
 
 ```java
+class Solution {
+    public int findNumberOfLIS(int[] nums) {
+        if (nums.length <= 1) return nums.length;
+        int[] dp = new int[nums.length];
+        for(int i = 0; i < dp.length; i++) dp[i] = 1;
+        int[] count = new int[nums.length];
+        for(int i = 0; i < count.length; i++) count[i] = 1;
+
+        int maxCount = 0;
+        for (int i = 1; i < nums.length; i++) {
+            for (int j = 0; j < i; j++) {
+                if (nums[i] > nums[j]) {
+                    if (dp[j] + 1 > dp[i]) {
+                        dp[i] = dp[j] + 1;
+                        count[i] = count[j];
+                    } else if (dp[j] + 1 == dp[i]) {
+                        count[i] += count[j];
+                    }
+                }
+                if (dp[i] > maxCount) maxCount = dp[i];
+            }
+        }
+        int result = 0;
+        for (int i = 0; i < nums.length; i++) {
+            if (maxCount == dp[i]) result += count[i];
+        }
+        return result;
+    }
+}
 ```
 
 ## Python
 
 ```python
+class Solution:
+    def findNumberOfLIS(self, nums: List[int]) -> int:
+        size = len(nums)
+        if size<= 1: return size
+
+        dp = [1 for i in range(size)]
+        count = [1 for i in range(size)]
+
+        maxCount = 0
+        for i in range(1, size):
+            for j in range(i):
+                if nums[i] > nums[j]:
+                    if dp[j] + 1 > dp[i] :
+                        dp[i] = dp[j] + 1
+                        count[i] = count[j]
+                    elif dp[j] + 1 == dp[i] :
+                        count[i] += count[j]
+                if dp[i] > maxCount:
+                    maxCount = dp[i];
+        result = 0
+        for i in range(size):
+            if maxCount == dp[i]:
+                result += count[i]
+        return result;
 ```
 
 ## Go
 
 ```go
+
+func findNumberOfLIS(nums []int) int {
+	size := len(nums)
+	if size <= 1  {
+		return size
+	}
+
+	dp := make([]int, size);
+	for i, _ := range dp {
+		dp[i] = 1
+	}
+	count := make([]int, size);
+	for i, _ := range count {
+		count[i] = 1
+	}
+
+	maxCount := 0
+	for i := 1; i < size; i++ {
+		for j := 0; j < i; j++ {
+			if nums[i] > nums[j] {
+				if dp[j] + 1 > dp[i] {
+					dp[i] = dp[j] + 1
+					count[i] = count[j]
+				} else if dp[j] + 1 == dp[i] {
+					count[i] += count[j]
+				}
+			}
+			if dp[i] > maxCount {
+				maxCount = dp[i]
+			}
+		}
+	}
+
+	result := 0
+	for i := 0; i < size; i++ {
+		if maxCount == dp[i] {
+			result += count[i]
+		}
+	}
+	return result
+}
 ```
 
 ## JavaScript


### PR DESCRIPTION
增加 673.最长递增子序列的个数 的 Java, Python, Go语言实现