### PR TITLE
0494.更新测试用例，原C++代码bagsize可能小于0而出错，其他语言可能也有类似问题。

### DIFF
--- a/problems/0494.目标和.md
+++ b/problems/0494.目标和.md
@@ -197,20 +197,27 @@ C++代码如下：
 ```CPP
 class Solution {
 public:
-    int findTargetSumWays(vector<int>& nums, int S) {
+    int findTargetSumWays(vector<int>& nums, int target) {
+        int n = nums.size();
+        if(n == 0)return 0;
         int sum = 0;
-        for (int i = 0; i < nums.size(); i++) sum += nums[i];
-        if (S > sum) return 0; // 此时没有方案
-        if ((S + sum) % 2 == 1) return 0; // 此时没有方案
-        int bagSize = (S + sum) / 2;
-        vector<int> dp(bagSize + 1, 0);
+        for(int i = 0; i < n; i++)
+        {
+            sum += nums[i];
+        }
+        int diff = sum - target;
+        if(diff % 2 == 1 || diff < 0)return 0;//此时没有方案
+        int bagsize = diff / 2;
+        vector<int>dp(bagsize + 1, 0);
         dp[0] = 1;
-        for (int i = 0; i < nums.size(); i++) {
-            for (int j = bagSize; j >= nums[i]; j--) {
+        for(int i = 0; i < n; i++)
+        {
+            for(int j = bagsize; j >= nums[i]; j--)
+            {
                 dp[j] += dp[j - nums[i]];
             }
         }
-        return dp[bagSize];
+        return dp[bagsize];
     }
 };
 


### PR DESCRIPTION
题目范围
1 <= nums.length <= 20
0 <= nums[i] <= 1000
0 <= sum(nums[i]) <= 1000
-1000 <= target <= 1000
新增测试用例[100] -200 导致原C++代码int bagsize = (sum + target) / 2;bagsize小于0而出错。
修改如下：
int diff = sum - target;
if(diff % 2 == 1 || diff < 0)return 0;
int bagsize = diff / 2;