### PR TITLE
更新 0053 最大子序和 JavaScript 解法

### DIFF
--- a/problems/0053.最大子序和（动态规划）.md
+++ b/problems/0053.最大子序和（动态规划）.md
@@ -173,7 +173,8 @@ JavaScript：
 ```javascript
 const maxSubArray = nums => {
     // 数组长度，dp初始化
-    const [len, dp] = [nums.length, [nums[0]]];
+    const len = nums.length;
+    let dp = new Array(len).fill(0);
     // 最大值初始化为dp[0]
     let max = dp[0];
     for (let i = 1; i < len; i++) {


### PR DESCRIPTION
既然已经知道dp数组长度，初始化时就应该创建一个固定长度的数组，而不是直接用 [nums[0]] 代替，这样会影响性能