### PR TITLE
纠正 0376 摆动序列 JavaScript版本代码区间错误 问题

### DIFF
--- a/problems/0376.摆动序列.md
+++ b/problems/0376.摆动序列.md
@@ -177,7 +177,7 @@ var wiggleMaxLength = function(nums) {
     let result = 1
     let preDiff = 0
     let curDiff = 0
-    for(let i = 0; i <= nums.length; i++) {
+    for(let i = 0; i < nums.length - 1; i++) {
         curDiff = nums[i + 1] - nums[i]
         if((curDiff > 0 && preDiff <= 0) || (curDiff < 0 && preDiff >= 0)) {
             result++


### PR DESCRIPTION
原代码中 存在 区间超出范围问题， 现给出修改方案