### PR TITLE
删除 0494 目标和 JavaScript版本代码中的排序操作

### DIFF
--- a/problems/0494.目标和.md
+++ b/problems/0494.目标和.md
@@ -371,7 +371,6 @@ const findTargetSumWays = (nums, target) => {
     }
 
     const halfSum = (target + sum) / 2;
-    nums.sort((a, b) => a - b);
 
     let dp = new Array(halfSum+1).fill(0);
     dp[0] = 1;


### PR DESCRIPTION
对原数组升序排序是没有必要的