### PR TITLE
纠正 0279 完全平方数 JavaScript版本代码错误

### DIFF
--- a/problems/0279.完全平方数.md
+++ b/problems/0279.完全平方数.md
@@ -334,8 +334,8 @@ var numSquares1 = function(n) {
     let dp = new Array(n + 1).fill(Infinity)
     dp[0] = 0
 
-    for(let i = 0; i <= n; i++) {
-        let val = i * i
+    for(let i = 1; i**2 <= n; i++) {
+        let val = i**2
         for(let j = val; j <= n; j++) {
             dp[j] = Math.min(dp[j], dp[j - val] + 1)
         }


### PR DESCRIPTION
首先 0 不是题目中所说的完全平方数，所有 i 的范围应该从 1 开始；
其次，i <= n 不太合理，增加了大量无用计算，应改成 i**2 （即 i^2）<= n 更为合适