### PR TITLE
纠正 0122 买卖股票最佳时机II 的JavaScript版本代码错误

### DIFF
--- a/problems/0122.买卖股票的最佳时机II（动态规划）.md
+++ b/problems/0122.买卖股票的最佳时机II（动态规划）.md
@@ -232,8 +232,10 @@ const maxProfit = (prices) => {
         have = -prices[0],
         notHave = 0;
     for (let i = 1; i < n; i++) {
-        have = Math.max(have, notHave - prices[i]);
-        notHave = Math.max(notHave, have + prices[i]);
+        let newHave = Math.max(have, notHave - prices[i]);
+        let newNotHave = Math.max(notHave, have + prices[i]);
+        have = newHave;
+        notHave = newNotHave;
     }
     // 最终手里不持有股票才能保证收益最大化
     return notHave;


### PR DESCRIPTION
滚动数组解法进行状态转移时。应先将上一次的状态另存，再更新状态。原代码中在求 notHave 状态时使用的状态have,其实已经不是之前的状态了，而是更新后的最新状态，这显然与状态转移方程不服。虽然测试用例可以通过，但我认为原代码这样的写法是不合理的。