### PR TITLE
更新 0019.删除链表的倒数第N个节点 错别字勘误

### DIFF
--- a/problems/0019.删除链表的倒数第N个节点.md
+++ b/problems/0019.删除链表的倒数第N个节点.md
@@ -50,7 +50,7 @@
 * fast首先走n + 1步 ，为什么是n+1呢，因为只有这样同时移动的时候slow才能指向删除节点的上一个节点（方便做删除操作），如图：
 <img src='https://code-thinking.cdn.bcebos.com/pics/19.%E5%88%A0%E9%99%A4%E9%93%BE%E8%A1%A8%E7%9A%84%E5%80%92%E6%95%B0%E7%AC%ACN%E4%B8%AA%E8%8A%82%E7%82%B91.png' width=600> </img></div>
 
-* fast和slow同时移动，之道fast指向末尾，如题：
+* fast和slow同时移动，直到fast指向末尾，如题：
 <img src='https://code-thinking.cdn.bcebos.com/pics/19.%E5%88%A0%E9%99%A4%E9%93%BE%E8%A1%A8%E7%9A%84%E5%80%92%E6%95%B0%E7%AC%ACN%E4%B8%AA%E8%8A%82%E7%82%B92.png' width=600> </img></div>
 
 * 删除slow指向的下一个节点，如图：


### PR DESCRIPTION
第 38 行处，之道 -> 直到

错误版本：
```
fast和slow同时移动，之道fast指向末尾
```
修正版本：
```
fast和slow同时移动，直到fast指向末尾
```