### PR TITLE
更新 面试题02.07.链表相交 错别字勘误

### DIFF
--- a/problems/面试题02.07.链表相交.md
+++ b/problems/面试题02.07.链表相交.md
@@ -38,7 +38,7 @@
 
 ![面试题02.07.链表相交_2](https://code-thinking.cdn.bcebos.com/pics/面试题02.07.链表相交_2.png)
 
-此时我们就可以比较curA和curB是否相同，如果不相同，同时向后移动curA和curB，如果遇到curA == curB，则找到焦点。
+此时我们就可以比较curA和curB是否相同，如果不相同，同时向后移动curA和curB，如果遇到curA == curB，则找到交点。
 
 否则循环退出返回空指针。
 


### PR DESCRIPTION
第 41 行处，焦点 -> 交点

修改前：
```
如果遇到curA == curB，则找到焦点。
```

修改后：
```
如果遇到curA == curB，则找到交点。
```