### PR TITLE
修复 0077.组合 python未剪枝和剪枝代码一样的问题

### DIFF
--- a/problems/0077.组合.md
+++ b/problems/0077.组合.md
@@ -405,7 +405,7 @@ class Solution:
             if len(path) == k:
                 res.append(path[:])
                 return
-            for i in range(StartIndex, n-(k-len(path)) + 2):
+            for i in range(StartIndex, n + 1):
                 path.append(i)
                 backtrack(n, k, i+1)
                 path.pop()
@@ -414,7 +414,7 @@ class Solution:
 ``` 
 
 剪枝：
-```python3
+```python
 class Solution:
     def combine(self, n: int, k: int) -> List[List[int]]:
         res=[]  #存放符合条件结果的集合
@@ -423,7 +423,7 @@ class Solution:
             if len(path) == k:
                 res.append(path[:])
             return 
-            for i in range(startIndex,n-(k-len(path))+2):  #优化的地方
+            for i in range(startIndex,n - (k - len(path)) + 2):  #优化的地方
                 path.append(i)  #处理节点 
                 backtrack(n,k,i+1)  #递归
                 path.pop()  #回溯，撤销处理的节点


### PR DESCRIPTION
 之前python版本的 0077.组合 未剪枝和剪枝代码一样，修复此问题，并且改了一下格式。