### PR TITLE
fix Qn0077 Python indent

### DIFF
--- a/problems/0077.组合.md
+++ b/problems/0077.组合.md
@@ -422,7 +422,7 @@ class Solution:
         def backtrack(n,k,startIndex):
             if len(path) == k:
                 res.append(path[:])
-            return 
+                return
             for i in range(startIndex,n - (k - len(path)) + 2):  #优化的地方
                 path.append(i)  #处理节点 
                 backtrack(n,k,i+1)  #递归

--- a/problems/0077.组合.md
+++ b/problems/0077.组合.md
@@ -427,8 +427,8 @@ class Solution:
                 path.append(i)  #处理节点 
                 backtrack(n,k,i+1)  #递归
                 path.pop()  #回溯，撤销处理的节点
-    backtrack(n,k,1)
-    return res
+        backtrack(n,k,1)
+        return res
 ```
 
 

--- a/problems/0077.组合优化.md
+++ b/problems/0077.组合优化.md
@@ -182,7 +182,7 @@ class Solution:
         def backtrack(n,k,startIndex):
             if len(path) == k:
                 res.append(path[:])
-            return 
+                return
             for i in range(startIndex,n-(k-len(path))+2):  #优化的地方
                 path.append(i)  #处理节点 
                 backtrack(n,k,i+1)  #递归

--- a/problems/0077.组合优化.md
+++ b/problems/0077.组合优化.md
@@ -187,8 +187,8 @@ class Solution:
                 path.append(i)  #处理节点 
                 backtrack(n,k,i+1)  #递归
                 path.pop()  #回溯，撤销处理的节点
-    backtrack(n,k,1)
-    return res
+        backtrack(n,k,1)
+        return res
 ```
 Go：
 ```Go

--- a/problems/0216.组合总和III.md
+++ b/problems/0216.组合总和III.md
@@ -323,7 +323,6 @@ class Solution:
             self.backtracking(k, n, i + 1)
             self.path.pop()
             self.sum_now -= i
-        return
 ```
 
 ## Go


### PR DESCRIPTION
Fix some indentation errors for the python3 solution of questions 0077 & 0216.
- the return statement should be added within the `if` block instead
- the following lines are in the wrong indent block
```python
backtrack(n,k,1)
return res
```
- remove an unnecessary `return`