### PR TITLE
添加 (0583.两个字符串的删除操作.md) : 增加解题思路 & 更新 背包问题理论基础完全背包：修正代码边界问题

### DIFF
--- a/problems/0583.两个字符串的删除操作.md
+++ b/problems/0583.两个字符串的删除操作.md
@@ -18,6 +18,8 @@
 
 ## 思路 
 
+### 动态规划一
+
 本题和[动态规划：115.不同的子序列](https://programmercarl.com/0115.不同的子序列.html)相比，其实就是两个字符串都可以删除了，情况虽说复杂一些，但整体思路是不变的。
 
 这次是两个字符串可以相互删了，这种题目也知道用动态规划的思路来解，动规五部曲，分析如下：
@@ -93,6 +95,29 @@ public:
             }
         }
         return dp[word1.size()][word2.size()];
+    }
+};
+
+```
+
+### 动态规划二
+
+本题和[动态规划：1143.最长公共子序列](https://programmercarl.com/1143.最长公共子序列.html)基本相同，只要求出两个字符串的最长公共子序列长度即可，那么除了最长公共子序列之外的字符都是必须删除的，最后用两个字符串的总长度减去两个最长公共子序列的长度就是删除的最少步数。
+
+代码如下：
+
+```CPP
+class Solution {
+public:
+    int minDistance(string word1, string word2) {
+        vector<vector<int>> dp(word1.size()+1, vector<int>(word2.size()+1, 0));
+        for (int i=1; i<=word1.size(); i++){
+            for (int j=1; j<=word2.size(); j++){
+                if (word1[i-1] == word2[j-1]) dp[i][j] = dp[i-1][j-1] + 1;
+                else dp[i][j] = max(dp[i-1][j], dp[i][j-1]);
+            }
+        }
+        return word1.size()+word2.size()-dp[word1.size()][word2.size()]*2;
     }
 };
 

--- a/problems/背包问题理论基础完全背包.md
+++ b/problems/背包问题理论基础完全背包.md
@@ -52,7 +52,7 @@ for(int i = 0; i < weight.size(); i++) { // 遍历物品
 ```CPP
 // 先遍历物品，再遍历背包
 for(int i = 0; i < weight.size(); i++) { // 遍历物品
-    for(int j = weight[i]; j < bagWeight ; j++) { // 遍历背包容量
+    for(int j = weight[i]; j <= bagWeight ; j++) { // 遍历背包容量
         dp[j] = max(dp[j], dp[j - weight[i]] + value[i]);
 
     }


### PR DESCRIPTION
比较01背包和完全背包核心代码时，完全背包遍历背包容量的边界有误，应该与下面的C++详细代码一致
添加 (0583.两个字符串的删除操作.md) : 增加解题思路