### PR TITLE
Fix Qn0416 spelling error

### DIFF
--- a/problems/0416.分割等和子集.md
+++ b/problems/0416.分割等和子集.md
@@ -253,14 +253,14 @@ Python：
 ```python
 class Solution:
     def canPartition(self, nums: List[int]) -> bool:
-        taraget = sum(nums)
-        if taraget % 2 == 1: return False
-        taraget //= 2
+        target = sum(nums)
+        if target % 2 == 1: return False
+        target //= 2
         dp = [0] * 10001
         for i in range(len(nums)):
-            for j in range(taraget, nums[i] - 1, -1):
+            for j in range(target, nums[i] - 1, -1):
                 dp[j] = max(dp[j], dp[j - nums[i]] + nums[i])
-        return taraget == dp[taraget]
+        return target == dp[target]
 ```
 Go：
 ```go


### PR DESCRIPTION
Fix the spelling of "taraget" => "target"