### PR TITLE
fix js螺旋数组

### DIFF
--- a/problems/0059.螺旋矩阵II.md
+++ b/problems/0059.螺旋矩阵II.md
@@ -246,11 +246,11 @@ var generateMatrix = function(n) {
             res[row][col] = count++;
         }
         // 下行从右到左（左闭右开）
-        for (; col > startX; col--) {
+        for (; col > startY; col--) {
             res[row][col] = count++;
         }
         // 左列做下到上（左闭右开）
-        for (; row > startY; row--) {
+        for (; row > startX; row--) {
             res[row][col] = count++;
         }
 


### PR DESCRIPTION
js螺旋数组，在旋转比较的时候，X，Y坐标错误