### PR TITLE
更新了0077.组合.md 中java版本的代码，消除了原来方法中需要使用的startindex形参

### DIFF
--- a/problems/0077.组合.md
+++ b/problems/0077.组合.md
@@ -343,24 +343,24 @@ class Solution {
     List<List<Integer>> result = new ArrayList<>();
     LinkedList<Integer> path = new LinkedList<>();
     public List<List<Integer>> combine(int n, int k) {
-        combineHelper(n, k, 1);
+        combineHelper(n, k);
         return result;
     }
 
     /**
-     * 每次从集合中选取元素，可选择的范围随着选择的进行而收缩，调整可选择的范围，就是要靠startIndex
-     * @param startIndex 用来记录本层递归的中，集合从哪里开始遍历（集合就是[1,...,n] ）。
+     * 每次从集合中选取元素，从后往前遍历，可选择的范围随着选择的进行而收缩，调整可选择的范围，每次添加元素后
+     * 新的元素是从[1, i]中选择, i 为新添加的元素
      */
-    private void combineHelper(int n, int k, int startIndex){
+    private void combineHelper(int n, int k){
         //终止条件
-        if (path.size() == k){
-            result.add(new ArrayList<>(path));
+        if(k == 0){
+            result.add(new ArrayList(path));
             return;
         }
-        for (int i = startIndex; i <= n - (k - path.size()) + 1; i++){
+        for(int i = n; i >= 1; i--){
             path.add(i);
-            combineHelper(n, k, i + 1);
-            path.removeLast();
+            combineHelper(i-1,k-1);
+            path.remove(path.size()-1);
         }
     }
 }


### PR DESCRIPTION
原本的逻辑是按照从前到后到顺序遍历，这样需要startindex这一形参来控制范围，但如果反过来，从后往前遍历，这样就可以通过减一的方式来减少右边界的方式来控制范围。