### PR TITLE
Update 0739.每日温度.md

### DIFF
--- a/problems/0739.每日温度.md
+++ b/problems/0739.每日温度.md
@@ -192,7 +192,7 @@ class Solution {
         否则的话，可以直接入栈。
         注意，单调栈里 加入的元素是 下标。
         */
-        Stack<Integer>stack=new Stack<>();
+        Deque<Integer> stack=new LinkedList<>();
         stack.push(0);
         for(int i=1;i<lens;i++){
             
@@ -216,7 +216,7 @@ class Solution {
     public int[] dailyTemperatures(int[] temperatures) {
         int lens=temperatures.length;
         int []res=new int[lens];
-        Stack<Integer>stack=new Stack<>();
+        Deque<Integer> stack=new LinkedList<>();
         for(int i=0;i<lens;i++){
             
            while(!stack.isEmpty()&&temperatures[i]>temperatures[stack.peek()]){


### PR DESCRIPTION
Java栈用LinkedList实现更快,因为默认的stack用的是Vector实现的,而Vector因为加锁了所以非常慢;
``` java
Stack<Integer> stack=new Stack<>();
```
``` bash
16:34	info
			解答成功:
			执行耗时:189 ms,击败了27.62% 的Java用户
			内存消耗:53.3 MB,击败了47.34% 的Java用户
```

``` java
Deque<Integer> stack=new LinkedList<>();
```
``` bash
16:27	info
			解答成功:
			执行耗时:25 ms,击败了69.42% 的Java用户
			内存消耗:56.8 MB,击败了19.39% 的Java用户
```