### PR TITLE
纠正 0131 分割回文串 JavaScript 版本代码

### DIFF
--- a/problems/0131.分割回文串.md
+++ b/problems/0131.分割回文串.md
@@ -442,7 +442,7 @@ var partition = function(s) {
         }
         for(let j = i; j < len; j++) {
             if(!isPalindrome(s, i, j)) continue;
-            path.push(s.substr(i, j - i + 1));
+            path.push(s.slice(i, j + 1));
             backtracking(j + 1);
             path.pop();
         }


### PR DESCRIPTION
String 实例方法 substr 已弃用，请换成 slice