### PR TITLE
纠正 0093.复制IP地址 JavaScript 版本代码

### DIFF
--- a/problems/0093.复原IP地址.md
+++ b/problems/0093.复原IP地址.md
@@ -444,7 +444,7 @@ var restoreIpAddresses = function(s) {
             return;
         }
         for(let j = i; j < s.length; j++) {
-            const str = s.substr(i, j - i + 1);
+            const str = s.slice(i, j + 1);
             if(str.length > 3 || +str > 255) break;
             if(str.length > 1 && str[0] === "0") break;
             path.push(str);


### PR DESCRIPTION
String 实例 substr 方法已弃用，请使用 slice 方法