### PR TITLE
纠正 0078.子集问题 JS 、TS 版本代码

### DIFF
--- a/problems/0078.子集.md
+++ b/problems/0078.子集.md
@@ -260,7 +260,7 @@ var subsets = function(nums) {
     let result = []
     let path = []
     function backtracking(startIndex) {
-        result.push(path.slice())
+        result.push([...path])
         for(let i = startIndex; i < nums.length; i++) {
             path.push(nums[i])
             backtracking(i + 1)
@@ -280,7 +280,7 @@ function subsets(nums: number[]): number[][] {
     backTracking(nums, 0, []);
     return resArr;
     function backTracking(nums: number[], startIndex: number, route: number[]): void {
-        resArr.push(route.slice());
+        resArr.push([...route]);
         let length = nums.length;
         if (startIndex === length) return;
         for (let i = startIndex; i < length; i++) {


### PR DESCRIPTION
JS 和 TS 里面 数组深拷贝一般采用 ES6 扩展运算符 ... ，或者 Array.from() 方法，而不会采用实例方法 slice. slice方法用于数组分割等操作，请注意代码书写规范！