### PR TITLE
修正 0090.子集II JS、TS版本代码

### DIFF
--- a/problems/0090.子集II.md
+++ b/problems/0090.子集II.md
@@ -299,7 +299,7 @@ var subsetsWithDup = function(nums) {
         return a - b
     })
     function backtracing(startIndex, sortNums) {
-        result.push(path.slice(0))
+        result.push([...path])
         if(startIndex > nums.length - 1) {
             return
         }
@@ -327,7 +327,7 @@ function subsetsWithDup(nums: number[]): number[][] {
     backTraking(nums, 0, []);
     return resArr;
     function backTraking(nums: number[], startIndex: number, route: number[]): void {
-        resArr.push(route.slice());
+        resArr.push([...route]);
         let length: number = nums.length;
         if (startIndex === length) return;
         for (let i = startIndex; i < length; i++) {


### PR DESCRIPTION
JS 和 TS 里面 数组深拷贝一般采用 ES6 扩展运算符 ... ，或者 Array.from() 方法，而不会采用实例方法 slice. slice方法用于数组分割等操作，请注意代码书写规范！