### PR TITLE
纠正 0046.全排列 TS 版本代码

### DIFF
--- a/problems/0046.全排列.md
+++ b/problems/0046.全排列.md
@@ -341,7 +341,7 @@ function permute(nums: number[]): number[][] {
     return resArr;
     function backTracking(nums: number[], route: number[]): void {
         if (route.length === nums.length) {
-            resArr.push(route.slice());
+            resArr.push([...route]);
             return;
         }
         let tempVal: number;


### PR DESCRIPTION
JS 和 TS 里面 数组深拷贝一般采用 ES6 扩展运算符 ... ，或者 Array.from() 方法，而不会采用实例方法 slice. slice方法用于数组分割等操作，请注意代码书写规范！