### PR TITLE
纠正 0047.全排列II JS、TS 版本代码

### DIFF
--- a/problems/0047.全排列II.md
+++ b/problems/0047.全排列II.md
@@ -268,7 +268,7 @@ var permuteUnique = function (nums) {
 
     function backtracing( used) {
         if (path.length === nums.length) {
-            result.push(path.slice())
+            result.push([...path])
             return
         }
         for (let i = 0; i < nums.length; i++) {
@@ -303,7 +303,7 @@ function permuteUnique(nums: number[]): number[][] {
     return resArr;
     function backTracking(nums: number[], route: number[]): void {
         if (route.length === nums.length) {
-            resArr.push(route.slice());
+            resArr.push([...route]);
             return;
         }
         for (let i = 0, length = nums.length; i < length; i++) {


### PR DESCRIPTION
JS 和 TS 里面 数组深拷贝一般采用 ES6 扩展运算符 ... ，或者 Array.from() 方法，而不会采用实例方法 slice. slice方法用于数组分割等操作，请注意代码书写规范！