### PR TITLE
更新 111.二叉树的最小深度 的拼写错误及改进规范

### DIFF
--- a/problems/0102.二叉树的层序遍历.md
+++ b/problems/0102.二叉树的层序遍历.md
@@ -2393,21 +2393,21 @@ JavaScript：
 var minDepth = function(root) {
     if (root === null) return 0;
     let queue = [root];
-    let deepth = 0;
+    let depth = 0;
     while (queue.length) {
         let n = queue.length;
-        deepth++;
+        depth++;
         for (let i=0; i<n; i++) {
             let node = queue.shift();
-            // 如果左右节点都是null，则该节点深度最小
+            // 如果左右节点都是null(在遇见的第一个leaf节点上)，则该节点深度最小
             if (node.left === null && node.right === null) {
-                return deepth;
+                return depth;
             }
             node.left && queue.push(node.left);;
-            node.right && queue.push (node.right);
+            node.right && queue.push(node.right);
         }
     }
-    return deepth;
+    return depth;
 };
 ```
 


### PR DESCRIPTION
1. 单词正确拼写为depth。
2. 加入解释性注释
3. 删除多余的空格