### PR TITLE
更新了 0376-摆动序列 动态规划做法：O(n)时间复杂度dp

### DIFF
--- a/problems/0376.摆动序列.md
+++ b/problems/0376.摆动序列.md
@@ -200,30 +200,28 @@ class Solution {
 // DP
 class Solution {
     public int wiggleMaxLength(int[] nums) {
-        // 0 i 作为波峰的最大长度
-        // 1 i 作为波谷的最大长度
-        int dp[][] = new int[nums.length][2];
-
-        dp[0][0] = dp[0][1] = 1;
-        for (int i = 1; i < nums.length; i++){
-            //i 自己可以成为波峰或者波谷
-            dp[i][0] = dp[i][1] = 1;
-
-            for (int j = 0; j < i; j++){
-                if (nums[j] > nums[i]){
-                    // i 是波谷
-                    dp[i][1] = Math.max(dp[i][1], dp[j][0] + 1);
-                }
-                if (nums[j] < nums[i]){
-                    // i 是波峰
-                    dp[i][0] = Math.max(dp[i][0], dp[j][1] + 1);
-                }
-            }
-        }
-
-        return Math.max(dp[nums.length - 1][0], dp[nums.length - 1][1]);
+        // dp[i][0]：以i结尾上升的最长摆动序列
+        // dp[i][1]：以i结尾下降的最长摆动序列
+         int n = nums.length;
+         int[][] dp = new int[n][2];
+         dp[0][0] = 1;
+         dp[0][1] = 1;
+         for(int i = 1; i < n; i++) {
+             if(nums[i] - nums[i - 1] == 0) {
+                 dp[i][0] = dp[i - 1][0];
+                 dp[i][1] = dp[i - 1][1];
+             } else if(nums[i] - nums[i - 1] > 0) {
+                 dp[i][0] = dp[i - 1][1] + 1;
+                 dp[i][1] = dp[i - 1][1];
+             } else {
+                 dp[i][1] = dp[i - 1][0] + 1;
+                 dp[i][0] = dp[i - 1][0];
+             }
+         }
+         return Math.max(dp[n - 1][0], dp[n - 1][1]);
     }
 }
+
 ```
 
 ### Python 


### PR DESCRIPTION
【分析】：对于数组中出现的每一个数，仅有三种情况：
1). 要么是作为山峰（即nums[i] > nums[i-1]）
2). 要么是作为山谷（即nums[i] < nums[i - 1]）
3). 要么都不是（nums[i] == nums[i - 1]）
4). 特殊情况（i == 0）时既可以视为山峰、也可以视为山谷。

【动态规划】：
1. dp定义：dp[i][2] (虽然每个数有三种状态，但我们只需要考虑山峰和山谷两种状态即可)
- dp[i][0]：当前数nums[i]作为序列山峰的最大序列长度
- dp[i][1]：当前数nums[i]作为序列山谷的最大序列长度
2. 状态转移
根据摆动序列的定义，序列末尾（nums[i]）为山峰，则序列倒数第二位（nums[i-1]）为山谷，此时序列长度为以前一位数（nums[i-1]）为山谷的序列长度+1；
同理，序列末尾（nums[i]）为山谷，倒数第二位（nums[i-1]）为山峰，此时序列长度为以前一位数（nums[i-1]）为山峰的序列长度+1。因此状态转移方程如下：
（1) 当前数nums[i]为山峰(nums[i] > nums[i-1])，则:
```
dp[i][0] = dp[i-1][1] + 1;
dp[i][1] = dp[i-1][1];
```
（2) 当前数nums[i]为山谷(nums[i] < nums[i-1])，则:
```
dp[i][0] = dp[i-1][0] ;
dp[i][1] = dp[i-1][0] + 1;
```
（3) 当前数nums[i]与前一位nums[i-1]相等(nums[i] == nums[i-1])，则:
```
dp[i][0] = dp[i-1][0];
dp[i][1] = dp[i-1][1];
```
3. 初始化： i == 0 时既可以视为山峰、也可以视为山谷，因此：
```
dp[0][0] = dp[0][1] = 1
```
【复杂度】：
时间复杂度：只遍历了一边数组，所以时间复杂度为O(n);
空间复杂度：定义了长度为n的二维数组，因此空间复杂度为O(n)；发现每个位置的状态只与前一个位置状态有关，因此可以做常数优化，空间复杂度降低至O(1)。