### PR TITLE
Update 0347.前K个高频元素.md

### DIFF
--- a/problems/0347.前K个高频元素.md
+++ b/problems/0347.前K个高频元素.md
@@ -146,7 +146,7 @@ class Solution {
         for (Map.Entry<Integer, Integer> entry : entries) {
             queue.offer(entry);
         }
-        for (int i = k - 1; i >= 0; i--) {
+        for (int i = 0; i < k; i++) {
             result[i] = queue.poll().getKey();
         }
         return result;


### PR DESCRIPTION
fix java code bug:
因为构造的大顶堆，所以直接按顺序输出