### PR TITLE
530.二叉搜索树的最小绝对差 python迭代法没有取abs

### DIFF
--- a/problems/0530.二叉搜索树的最小绝对差.md
+++ b/problems/0530.二叉搜索树的最小绝对差.md
@@ -233,7 +233,7 @@ class Solution:
             else: # 逐一处理节点
                 cur = stack.pop()
                 if pre: # 当前节点和前节点的值的差值
-                    result = min(result, cur.val - pre.val)
+                    result = min(result, abs(cur.val - pre.val))
                 pre = cur
                 cur = cur.right
         return result


### PR DESCRIPTION
如题
原写法
result = min(result, cur.val - pre.val)

改为
result = min(result, abs(cur.val - pre.val))