### PR TITLE
更新376.摆动序列 贪心算法Go语言版本

### DIFF
--- a/problems/0376.摆动序列.md
+++ b/problems/0376.摆动序列.md
@@ -269,18 +269,23 @@ class Solution:
 **贪心**
 ```golang
 func wiggleMaxLength(nums []int) int {
-	var count, preDiff, curDiff int //初始化默认为0
-	count = 1                       // 初始化为1，因为最小的序列是1个数
-	if len(nums) < 2 {
-		return count
+	n := len(nums)
+	if n < 2 {
+		return n
 	}
-	for i := 0; i < len(nums)-1; i++ {
-		curDiff = nums[i+1] - nums[i]
-		if (curDiff > 0 && preDiff <= 0) || (curDiff < 0 && preDiff >= 0) {
-			count++
+	ans := 1
+	prevDiff := nums[1] - nums[0]
+	if prevDiff != 0 {
+		ans = 2
+	}
+	for i := 2; i < n; i++ {
+		diff := nums[i] - nums[i-1]
+		if diff > 0 && prevDiff <= 0 || diff < 0 && prevDiff >= 0 {
+			ans++
+			prevDiff = diff
 		}
 	}
-	return count
+	return ans
 }
 ```
 


### PR DESCRIPTION
原Go语言代码无法通过全部用例
nums = [1,17,5,10,13,15,10,5,16,8]
预期结果：7
实际输出：10