### PR TITLE
更新了0377.组合总和Ⅳ的c++代码

### DIFF
--- a/problems/0377.组合总和Ⅳ.md
+++ b/problems/0377.组合总和Ⅳ.md
@@ -112,11 +112,11 @@ dp[i]（考虑nums[j]）可以由 dp[i - nums[j]]（不考虑nums[j]） 推导�
 class Solution {
 public:
     int combinationSum4(vector<int>& nums, int target) {
-        vector<int> dp(target + 1, 0);
+        vector<unsigned long long> dp(target + 1, 0);
         dp[0] = 1;
         for (int i = 0; i <= target; i++) { // 遍历背包
             for (int j = 0; j < nums.size(); j++) { // 遍历物品
-                if (i - nums[j] >= 0 && dp[i] < INT_MAX - dp[i - nums[j]]) {
+                if (i - nums[j] >= 0) {
                     dp[i] += dp[i - nums[j]];
                 }
             }
@@ -124,10 +124,9 @@ public:
         return dp[target];
     }
 };
-
 ```
 
-C++测试用例有两个数相加超过int的数据，所以需要在if里加上dp[i] < INT_MAX - dp[i - num]。
+dp数组使用unsigned long long是因为C++测试用例有两个数相加超过int的数据~~，所以需要在if里加上dp[i] < INT_MAX - dp[i - num]。~~
 
 但java就不用考虑这个限制，java里的int也是四个字节吧，也有可能leetcode后台对不同语言的测试数据不一样。
 


### PR DESCRIPTION
题中使用dp[i] < INT_MAX - dp[i - nums[j]]避免整数溢出，我将其删除，将dp数组元素的类型从int改为unsigned long long，亲测这样也能通过leetcode，且更加简洁。