### PR TITLE
更新了0239.滑动窗口最大值：python3的用例，替换list为deque，如果用list会超时的问题

### DIFF
--- a/problems/0239.滑动窗口最大值.md
+++ b/problems/0239.滑动窗口最大值.md
@@ -296,16 +296,19 @@ class Solution {
 ```
 
 Python：
-```python
+```python3
+from collections import deque
+
+
 class MyQueue: #单调队列（从大到小
     def __init__(self):
-        self.queue = [] #使用list来实现单调队列
+        self.queue = deque() #这里需要使用deque实现单调队列，直接使用list会超时
     
     #每次弹出的时候，比较当前要弹出的数值是否等于队列出口元素的数值，如果相等则弹出。
     #同时pop之前判断队列当前是否为空。
     def pop(self, value):
         if self.queue and value == self.queue[0]:
-            self.queue.pop(0)#list.pop()时间复杂度为O(n),这里可以使用collections.deque()
+            self.queue.popleft()#list.pop()时间复杂度为O(n),这里需要使用collections.deque()
             
     #如果push的数值大于入口元素的数值，那么就将队列后端的数值弹出，直到push的数值小于等于队列入口元素的数值为止。
     #这样就保持了队列里的数值是单调从大到小的了。

--- a/problems/0239.滑动窗口最大值.md
+++ b/problems/0239.滑动窗口最大值.md
@@ -296,7 +296,7 @@ class Solution {
 ```
 
 Python：
-```python3
+```python
 from collections import deque
 
 


### PR DESCRIPTION
更新的代码已经在leetcode上完成测试
![image](https://user-images.githubusercontent.com/15166014/195083776-685501f4-a20a-4c1a-a299-5ed043bb961d.png)
