### PR TITLE
0349 fix code block language

### DIFF
--- a/problems/0349.两个数组的交集.md
+++ b/problems/0349.两个数组的交集.md
@@ -91,7 +91,7 @@ public:
 
 对应C++代码如下：
 
-```c++
+```CPP
 class Solution {
 public:
     vector<int> intersection(vector<int>& nums1, vector<int>& nums2) {


### PR DESCRIPTION
change language from `c++` to `CPP`, since `c++` doesn't get rendered as expected [here](https://programmercarl.com/0349.%E4%B8%A4%E4%B8%AA%E6%95%B0%E7%BB%84%E7%9A%84%E4%BA%A4%E9%9B%86.html#%E5%90%8E%E8%AE%B0).

官网没有正确渲染代码框语言，因此将语言更改为上文中的格式