### PR TITLE
Update 0084.柱状图中最大的矩形.md (Java版本)

### DIFF
--- a/problems/0084.柱状图中最大的矩形.md
+++ b/problems/0084.柱状图中最大的矩形.md
@@ -206,7 +206,7 @@ class Solution {
     public int largestRectangleArea(int[] heights) {
         int length = heights.length;
         int[] minLeftIndex = new int [length];
-        int[] maxRigthIndex = new int [length];
+        int[] minRightIndex = new int [length];
         // 记录左边第一个小于该柱子的下标
         minLeftIndex[0] = -1 ;
         for (int i = 1; i < length; i++) {
@@ -215,17 +215,17 @@ class Solution {
             while (t >= 0 && heights[t] >= heights[i]) t = minLeftIndex[t];
             minLeftIndex[i] = t;
         }
-        // 记录每个柱子 右边第一个小于该柱子的下标
-        maxRigthIndex[length - 1] = length;
+        // 记录每个柱子右边第一个小于该柱子的下标
+        minRightIndex[length - 1] = length;
         for (int i = length - 2; i >= 0; i--) {
             int t = i + 1;
-            while(t < length && heights[t] >= heights[i]) t = maxRigthIndex[t];
-            maxRigthIndex[i] = t;
+            while(t < length && heights[t] >= heights[i]) t = minRightIndex[t];
+            minRightIndex[i] = t;
         }
         // 求和
         int result = 0;
         for (int i = 0; i < length; i++) {
-            int sum = heights[i] * (maxRigthIndex[i] - minLeftIndex[i] - 1);
+            int sum = heights[i] * (minRightIndex[i] - minLeftIndex[i] - 1);
             result = Math.max(sum, result);
         }
         return result;


### PR DESCRIPTION
修改了0084.柱状图中最大的矩形.md中，动态规划Java版本命名不规范的问题。
1. right单词打错了
2. 寻找每个柱子右边第一个小于该柱子的下标应该命名为minRightIndex，而不是maxRightIndex