### PR TITLE
删除二叉树层序遍历637Java解法中没有必要的语句

### DIFF
--- a/problems/0102.二叉树的层序遍历.md
+++ b/problems/0102.二叉树的层序遍历.md
@@ -1072,7 +1072,6 @@ public class N0637 {
 
         que.offerLast(root);
         while (!que.isEmpty()) {
-            TreeNode peek = que.peekFirst();
 
             int levelSize = que.size();
             double levelSum = 0.0;
@@ -2970,3 +2969,4 @@ impl Solution {
 <a href="https://programmercarl.com/other/kstar.html" target="_blank">
   <img src="../pics/网站星球宣传海报.jpg" width="1000"/>
 </a>
+


### PR DESCRIPTION
'' TreeNode peek = que.peekFirst(); '' 这句程序语句在代码中没有起作用，并且没有必要存在。