### PR TITLE
Fix : TypeScript answer for binary-tree traversal

### DIFF
--- a/problems/二叉树的统一迭代法.md
+++ b/problems/二叉树的统一迭代法.md
@@ -536,9 +536,9 @@ function preorderTraversal(root: TreeNode | null): number[] {
         curNode = helperStack.pop()!;
         if (curNode !== null) {
             if (curNode.right !== null) helperStack.push(curNode.right);
+	    if (curNode.left !== null) helperStack.push(curNode.left);
             helperStack.push(curNode);
             helperStack.push(null);
-            if (curNode.left !== null) helperStack.push(curNode.left);
         } else {
             curNode = helperStack.pop()!;
             res.push(curNode.val);
@@ -579,9 +579,9 @@ function postorderTraversal(root: TreeNode | null): number[] {
     while (helperStack.length > 0) {
         curNode = helperStack.pop()!;
         if (curNode !== null) {
-            if (curNode.right !== null) helperStack.push(curNode.right);
-            helperStack.push(curNode);
+	    helperStack.push(curNode);
             helperStack.push(null);
+            if (curNode.right !== null) helperStack.push(curNode.right);
             if (curNode.left !== null) helperStack.push(curNode.left);
         } else {
             curNode = helperStack.pop()!;


### PR DESCRIPTION
* Fixing TypeScript traversal answers
- preoder / inorder / postorder has exactly same code, fixed.