### PR TITLE
fix subtract with overflow

### DIFF
--- a/problems/0977.有序数组的平方.md
+++ b/problems/0977.有序数组的平方.md
@@ -183,14 +183,14 @@ Rust
 impl Solution {
     pub fn sorted_squares(nums: Vec<i32>) -> Vec<i32> {
         let n = nums.len();
-        let (mut i,mut j,mut k) = (0,n - 1,n- 1);
+        let (mut i,mut j,mut k) = (0,n - 1,n);
         let mut ans = vec![0;n];
         while i <= j{
             if nums[i] * nums[i] < nums[j] * nums[j] {
-                ans[k] = nums[j] * nums[j];
+                ans[k-1] = nums[j] * nums[j];
                 j -= 1;
             }else{
-                ans[k] = nums[i] * nums[i];
+                ans[k-1] = nums[i] * nums[i];
                 i += 1;
             }
             k -= 1;


### PR DESCRIPTION
977. 有序数组的平方.md中，rust语言版本中，现存的版本是可以在leetcode上AC的，但是在本地测试时，回出现减法溢出。

原因如下：
```rust
impl Solution {
    pub fn sorted_squares(nums: Vec<i32>) -> Vec<i32> {
        let n = nums.len();
        let (mut i,mut j,mut k) = (0,n - 1,n- 1);
        let mut ans = vec![0;n];
        while i <= j{
            if nums[i] * nums[i] < nums[j] * nums[j] {
                ans[k] = nums[j] * nums[j];
                j -= 1;
            }else{
                ans[k] = nums[i] * nums[i];
                i += 1;
            }
            k -= 1;   // 当所有的数都处理完毕时，还会进行减去1的操作，但是k的数据类型时usize，因此编译器会报减法向下溢出，无法通过编译。
        }
        ans
    }
}


```
修改的方法是将k的基数增加1，也就是初始化 let mut k = n;
在进行赋值的时候将此index减去1，保证位置正确。