### PR TITLE
Update 0019.删除链表的倒数第N个节点.md

### DIFF
--- a/problems/0019.删除链表的倒数第N个节点.md
+++ b/problems/0019.删除链表的倒数第N个节点.md
@@ -129,10 +129,10 @@ class Solution:
         head_dummy.next = head
 
         slow, fast = head_dummy, head_dummy
-        while(n!=0): #fast先往前走n步
+        while(n>=0): #fast先往前走n+1步
             fast = fast.next
             n -= 1
-        while(fast.next!=None):
+        while(fast!=None):
             slow = slow.next
             fast = fast.next
         #fast 走到结尾后，slow的下一个节点为倒数第N个节点


### PR DESCRIPTION
修改python版本为：fast先走n+1步 （旧版本是fast走n步，然后判断fast.next!=None），这样与上面的讲解一致