### PR TITLE
Update 0112.路径总和.md

### DIFF
--- a/problems/0112.路径总和.md
+++ b/problems/0112.路径总和.md
@@ -477,7 +477,7 @@ class solution:
             return isornot(root, targetsum - root.val)
 ```
 
-**迭代 - 层序遍历**
+**迭代 - 前序遍历**
 
 ```python
 class solution:


### PR DESCRIPTION
python迭代法，应为“前序遍历”，原先写为“层序遍历”