### PR TITLE
更新 0206.翻转链表 rust双指针示例代码错误纠正

### DIFF
--- a/problems/0206.翻转链表.md
+++ b/problems/0206.翻转链表.md
@@ -623,7 +623,7 @@ impl Solution {
         let mut cur = head;
         let mut pre = None;
         while let Some(mut node) = cur.take() {
-            cur = node.next;
+            cur = node.next.take();
             node.next = pre;
             pre = Some(node);
         }
@@ -756,4 +756,3 @@ public ListNode reverseList(ListNode head) {
 <a href="https://programmercarl.com/other/kstar.html" target="_blank">
   <img src="../pics/网站星球宣传海报.jpg" width="1000"/>
 </a>
-


### PR DESCRIPTION
更新 0206.翻转链表 rust双指针示例代码错误纠正