### PR TITLE
增加了高位到低位遍历的算法，并对该算法优化，使得空间复杂度为O(1)，运行消耗时间为0ms

### DIFF
--- a/problems/0738.单调递增的数字.md
+++ b/problems/0738.单调递增的数字.md
@@ -162,8 +162,8 @@ class Solution {
 }
 ```
 
-
-java高位到低位遍历，需要创建集合，这样做空间复杂度就和n的位数相关（1ms）：  
+__高位到低位版：__
+java高位到低位遍历，需要创建集合，空间复杂度和n的位数相关（1ms）：  
   ```java
   class Solution {
     public int monotoneIncreasingDigits(int n) {

--- a/problems/0738.单调递增的数字.md
+++ b/problems/0738.单调递增的数字.md
@@ -163,6 +163,7 @@ class Solution {
 ```
 
 __高位到低位版：__
+
 java高位到低位遍历，需要创建集合，空间复杂度和n的位数相关（1ms）：  
   ```java
   class Solution {

--- a/problems/0738.单调递增的数字.md
+++ b/problems/0738.单调递增的数字.md
@@ -163,6 +163,169 @@ class Solution {
 ```
 
 
+java高位到低位遍历，需要创建集合，这样做空间复杂度就和n的位数相关（1ms）：  
+  ```java
+  class Solution {
+    public int monotoneIncreasingDigits(int n) {
+        //从高位到低位，不方便，低位到高位方便遍历，使用栈辅助
+        Stack<Integer> stack=new Stack<>();
+        int temp,length,size=1,res=0,padding;
+        //入栈操作
+        while (n >0) {
+            stack.push(n%10);
+            n = n / 10;
+        }
+        //获取n的位数
+        length=stack.size();
+        //开始高位到低位遍历
+        while (!stack.isEmpty()){
+            temp=stack.pop();
+            //当n的当前位的值大于等于高一位的值，高一位的值在res的个位上
+            if (temp>=res%10){
+                res*=10;
+                res+=temp;
+            }
+            //不满足
+            else {
+                /**
+                若res个位上开始到比它高的第k位存在连续相等的值，
+                例如对于n==1332，遍历构造res时存在res==133这一中间值，当对res做自减时，res==132，此时这一中间值不合法，
+                只能删除连续的3使得这一中间值严格单调递增，这样在做自减时就合法，例如res==133 ==> res==13 ==> res==12
+                **/
+                while (res%10==((res%100)/10)&&size>=2){
+                    res/=10;
+                    size--;
+                }
+                //res自减
+                res--;
+                //计算需要填充的9的个数
+                padding=length-size+1;
+                //填充的9
+                for (int i=0;i<padding;i++){
+                    res*=10;
+                    res+=9;
+                }
+                //提前返回
+                return res;
+            }
+            size++;
+        }
+        //未做9填充返回
+        return res;
+    }
+}
+  ```
+  
+可以看出一开始的解法和官方相似都借助了一个数据结构，空间复杂度n的位数相关。
+
+以以上代码为例，问题在于要遍历所以要借助数据结构。那么不借助数据结构如何遍历？观察之前的代码发现，取每一位可以借助求余和求商运算。那么对于$n$如何取最高位呢？答案就是：设$n$的位数为$k$，对于整型$n$，取最高位只需要求$n$除$10^k$。这样问题又变成了如何求$k$。求k也比较简单：当整型$q$有$10^{(q-1)} \leqslant n < 10^q$，那么$k=q-1$，于是我们便可以通过下面代码求$10^q$和$q$：
+
+```java
+int cur=1,length=1,temp,size=1,res=0,padding;
+while (cur<=n){
+    cur*=10;
+    length++;
+}
+```
+以上代码cur=$10^q$，length=$q$
+然后对求$10^k$和$k（k=q-1）$：
+
+```java
+cur/=10;
+length--;
+```
+
+但是以上代码还存在问题，有java整型二进制位数受限制，$10000000000（q=11）$存进整型会溢出即当$n=1000000000（k=10）$时上述代码不能正常运行，这里可以考虑将cur一开始设为long型变量，但是在这里我们不使这种方法。考虑$n$最大值为$1000000000（k=10）$，所以我们可以对这个值单独处理，当k<10时正常使用上面代码，于是最终：
+
+
+：
+```java
+int cur=1,length=1,temp,size=1,res=0,padding;
+while (cur<=n){
+    cur*=10;
+    length++;
+}
+cur/=10;
+length--;
+if (n==1000000000){
+    cur=n;
+    length=10;
+}
+```
+
+这样对于这道题就能完美求出$10^k$和$k$。
+之通过如下代码后便可从高位到低位遍历:
+
+```java
+for (int i=0;i<length;i++){
+    temp=n/cur;
+    //do something.....
+    n=n%cur;
+    cur=cur/10;
+}
+```
+
+__改进后，空间复杂度$O(1)$，消耗时间0ms__
+最终完成代码（0ms）：
+```java
+class Solution {
+    public int monotoneIncreasingDigits(int n){
+        if (n==0)return 0;
+        int cur=1,length=1,temp,size=1,res=0,padding;
+
+        //计算n的位数
+        while (cur<=n){
+            cur*=10;
+            length++;
+        }
+        cur/=10;
+        length--;
+        //对1000000000单独处理，防止整型溢出
+        if (n==1000000000){
+            cur=n;
+            length=10;
+        }
+
+        //遍历并构造n
+        for (int i=0;i<length;i++){
+            temp=n/cur;
+            //当前位大于等于高一位的数
+            if (temp>=res%10){
+                res*=10;
+                res+=temp;
+            }
+            //当前位小于高一位的数
+            else {
+                //回退，保证res自减合法
+                while (res%10==((res%100)/10)&&size>=2){
+                    res/=10;
+                    size--;
+                }
+                //res自减
+                res--;
+                //补9
+                padding=length-size+1;
+                for (int j=0;j<padding;j++){
+                    res*=10;
+                    res+=9;
+                }
+                //提前返回
+                return res;
+            }
+            size++;
+            n=n%cur;
+            cur=cur/10;
+        }
+        //res本身单调单调递增返回
+        return res;
+    }
+}
+```
+
+这里改进的是使用高位到低位遍历的算法，低位到高位应该也可以通过求余求商来进行改进，最终的空间复杂度应该均为$O(1)$。并且有于未使用数据结构，减少了数组对象构造时间（对于c，c++来说减少了向操作系统申请内存的时间），以及进行数组对象随机访问时计算内存地址的时间。
+
+
+
 ### Python：
 ```python 
 class Solution:


### PR DESCRIPTION
最近做了代码随想录贪心算法的单调递增数字，我看了官方的解法和代码随想录的解法发现这些解法均将输入的数字n变成数组的形式，这样做空间复杂度就和n的位数相关。但是将数字放入数组中是为了能够遍历每一位（10进制）数字。于是我就考虑了如何不用数组即可进行遍历，进而对算法的优化。


注：三次commit内容都差不多，只是前两次排版不好看