### PR TITLE
Update 0039.组合总和.md, 修复Python代码的一个bug

### DIFF
--- a/problems/0039.组合总和.md
+++ b/problems/0039.组合总和.md
@@ -311,7 +311,7 @@ class Solution:
 
         for i in range(startIndex, len(candidates)):
             if total + candidates[i] > target:
-                break
+                continue
             total += candidates[i]
             path.append(candidates[i])
             self.backtracking(candidates, target, total, i, path, result)


### PR DESCRIPTION
Python 版本的回溯剪枝版本一当中,  break 会终止整个for 循环，从而提前终止搜索，应该改成continue。