### PR TITLE
since 1 <= n <= sz, so `fast` can not be `nullptr`

### DIFF
--- a/problems/0019.删除链表的倒数第N个节点.md
+++ b/problems/0019.删除链表的倒数第N个节点.md
@@ -70,9 +70,7 @@ public:
         dummyHead->next = head;
         ListNode* slow = dummyHead;
         ListNode* fast = dummyHead;
-        while(n-- && fast != NULL) {
-            fast = fast->next;
-        }
+        while(n--) fast = fast->next;
         fast = fast->next; // fast再提前走一步，因为需要让slow指向删除节点的上一个节点
         while (fast != NULL) {
             fast = fast->next;


### PR DESCRIPTION
Constraints:

- The number of nodes in the list is sz.
- 1 <= sz <= 30
- 0 <= Node.val <= 100
- 1 <= n <= sz