### PR TITLE
update 151.翻转字符串里的单词 - Java错误注释修改

### DIFF
--- a/problems/0151.翻转字符串里的单词.md
+++ b/problems/0151.翻转字符串里的单词.md
@@ -311,7 +311,7 @@ class Solution {
 ```
 
 ```java
-//解法三：双反转+移位，在原始数组上进行反转。空间复杂度O(1)
+//解法三：双反转+移位，String 的 toCharArray() 方法底层会 new 一个和原字符串相同大小的 char 数组，空间复杂度：O(n)
 class Solution {
     /**
      * 思路：
@@ -976,3 +976,4 @@ char * reverseWords(char * s){
 <a href="https://programmercarl.com/other/kstar.html" target="_blank">
   <img src="../pics/网站星球宣传海报.jpg" width="1000"/>
 </a>
+

--- a/problems/0151.翻转字符串里的单词.md
+++ b/problems/0151.翻转字符串里的单词.md
@@ -976,4 +976,3 @@ char * reverseWords(char * s){
 <a href="https://programmercarl.com/other/kstar.html" target="_blank">
   <img src="../pics/网站星球宣传海报.jpg" width="1000"/>
 </a>
-


### PR DESCRIPTION
**问题描述**
String 的 toCharArray() 方法底层会 new 一个和原字符串相同大小的 char 数组。所以空间复杂度应该为 O（n），同时“用原始数组来进行反转操作”该表述也错了
**证明截图**
<img width="661" alt="Snipaste_2023-08-27_12-05-33" src="https://github.com/youngyangyang04/leetcode-master/assets/94028087/8d5528d0-20e2-43ad-b8ae-662958631ade">
<img width="600" alt="Snipaste_2023-08-27_12-10-03" src="https://github.com/youngyangyang04/leetcode-master/assets/94028087/c15cae87-dd1e-4781-8a9a-b7a8049846c6">

