### PR TITLE
update: 0053.最大子序和修复 ts 解法 BUG & 1035.不相交线 ts 新增滚动数组解法 & 优化 1035.不相交的线 ts 滚动数组代码注释 & 优化 0392.判断子序列 ts 二维数组解法代码逻辑 & 0392.判断子序列 ts 新增滚动数组解法。

### DIFF
--- a/problems/0053.最大子序和（动态规划）.md
+++ b/problems/0053.最大子序和（动态规划）.md
@@ -226,18 +226,20 @@ object Solution {
 
 ```typescript
 function maxSubArray(nums: number[]): number {
-    /**
-        dp[i]：以nums[i]结尾的最大和
-     */
-    const dp: number[] = []
-    dp[0] = nums[0];
-    let resMax: number = 0;
-    for (let i = 1; i < nums.length; i++) {
-        dp[i] = Math.max(dp[i - 1] + nums[i], nums[i]);
-        resMax = Math.max(resMax, dp[i]);
+    const len = nums.length
+    if (len === 1) return nums[0]
+
+    const dp: number[] = new Array(len)
+    let resMax: number = dp[0] = nums[0]
+
+    for (let i = 1; i < len; i++) {
+        dp[i] = Math.max(dp[i - 1] + nums[i], nums[i])
+        // 注意值为负数的情况
+        if (dp[i] > resMax) resMax = dp[i]
     }
-    return resMax;
-};
+
+    return resMax
+}
 ```
 
 

--- a/problems/0392.判断子序列.md
+++ b/problems/0392.判断子序列.md
@@ -216,6 +216,8 @@ const isSubsequence = (s, t) => {
 
 ### TypeScript：
 
+> 二维数组
+
 ```typescript
 function isSubsequence(s: string, t: string): boolean {
     /**
@@ -233,6 +235,31 @@ function isSubsequence(s: string, t: string): boolean {
         }
     }
     return dp[sLen][tLen] === s.length
+}
+```
+
+> 滚动数组
+```typescript
+function isSubsequence(s: string, t: string): boolean {
+    const sLen = s.length
+    const tLen = t.length
+    const dp: number[] = new Array(tLen + 1).fill(0)
+
+    for (let i = 1; i <= sLen; i++) {
+        let prev: number = 0;
+        let temp: number = 0;
+        for (let j = 1; j <= tLen; j++) {
+            // 备份一下当前状态（经过上层迭代后的）
+            temp = dp[j]
+            // prev 相当于 dp[j-1]（累加了上层的状态）
+            // 如果单纯 dp[j-1] 则不会包含上层状态
+            if (s[i - 1] === t[j - 1]) dp[j] = prev + 1
+            else dp[j] = dp[j - 1]
+            // 继续使用上一层状态更新参数用于当前层下一个状态
+            prev = temp
+        }
+    }
+    return dp[tLen] === sLen
 }
 ```
 

--- a/problems/0392.判断子序列.md
+++ b/problems/0392.判断子序列.md
@@ -221,21 +221,19 @@ function isSubsequence(s: string, t: string): boolean {
     /**
         dp[i][j]: s的前i-1个，t的前j-1个，最长公共子序列的长度
      */
-    const sLen: number = s.length,
-        tLen: number = t.length;
-    const dp: number[][] = new Array(sLen + 1).fill(0)
-        .map(_ => new Array(tLen + 1).fill(0));
+    const sLen = s.length
+    const tLen = t.length
+    const dp: number[][] = new Array(sLen + 1).fill(0).map(_ => new Array(tLen + 1).fill(0))
+
     for (let i = 1; i <= sLen; i++) {
         for (let j = 1; j <= tLen; j++) {
-            if (s[i - 1] === t[j - 1]) {
-                dp[i][j] = dp[i - 1][j - 1] + 1;
-            } else {
-                dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
-            }
+            if (s[i - 1] === t[j - 1]) dp[i][j] = dp[i - 1][j - 1] + 1
+            // 只需要取 j-2 的 dp 值即可，不用考虑 i-2
+            else dp[i][j] = dp[i][j - 1]
         }
     }
-    return dp[sLen][tLen] === s.length;
-};
+    return dp[sLen][tLen] === s.length
+}
 ```
 
 ### Go：

--- a/problems/1035.不相交的线.md
+++ b/problems/1035.不相交的线.md
@@ -257,13 +257,14 @@ function maxUncrossedLines(nums1: number[], nums2: number[]): number {
         let prev: number = 0;
         let temp: number = 0;
         for (let j = 1; j <= len2; j++) {
-            // 保存当前状态未计算前的值
+            // 备份一下当前状态（经过上层迭代后的）
             temp = dp[j]
-            // 使用没有累加的值进行累加
+            // prev 相当于 dp[j-1]（累加了上层的状态）
+            // 如果单纯 dp[j-1] 则不会包含上层状态
             if (nums1[i - 1] === nums2[j - 1]) dp[j] = prev + 1
             // dp[j] 表示之前的 dp[i][j-1]，dp[j-1] 表示 dp[i-1][j]
             else dp[j] = Math.max(dp[j], dp[j - 1])
-            // 下一个元素使用前一个状态未计算的值
+            // 继续使用上一层状态更新参数用于当前层下一个状态
             prev = temp
         }
     }

--- a/problems/1035.不相交的线.md
+++ b/problems/1035.不相交的线.md
@@ -221,6 +221,8 @@ const maxUncrossedLines = (nums1, nums2) => {
 
 ### TypeScript：
 
+> 二维数组
+
 ```typescript
 function maxUncrossedLines(nums1: number[], nums2: number[]): number {
     /**
@@ -242,6 +244,33 @@ function maxUncrossedLines(nums1: number[], nums2: number[]): number {
     return dp[length1][length2];
 };
 ```
+
+> 滚动数组
+```typescript
+function maxUncrossedLines(nums1: number[], nums2: number[]): number {
+    const len1 = nums1.length
+    const len2 = nums2.length
+
+    const dp: number[] = new Array(len2 + 1).fill(0)
+
+    for (let i = 1; i <= len1; i++) {
+        let prev: number = 0;
+        let temp: number = 0;
+        for (let j = 1; j <= len2; j++) {
+            // 保存当前状态未计算前的值
+            temp = dp[j]
+            // 使用没有累加的值进行累加
+            if (nums1[i - 1] === nums2[j - 1]) dp[j] = prev + 1
+            // dp[j] 表示之前的 dp[i][j-1]，dp[j-1] 表示 dp[i-1][j]
+            else dp[j] = Math.max(dp[j], dp[j - 1])
+            // 下一个元素使用前一个状态未计算的值
+            prev = temp
+        }
+    }
+    return dp[len2]
+}
+```
+
 
 <p align="center">
 <a href="https://programmercarl.com/other/kstar.html" target="_blank">


### PR DESCRIPTION
2023/10/28

第一个 `commit`：0053.最大子序和原本的 `typescript` 代码过不了 `leetcode`；

第二个 `commit`：1035.不相交线新增 `typescript` 滚动数组写法。

2023/10/29

第一个 `commit`：优化 1035.不相交的线 `typescript` 滚动数组代码注释；

第二个 `commit`：优化 0392.判断子序列 `typescript` 二维数组解法代码逻辑；

第三个 `commit`：0392.判断子序列 `typescript` 新增滚动数组解法。