### PR TITLE
修复两个字符串长度不一样的边界条件判断

### DIFF
--- a/problems/0242.有效的字母异位词.md
+++ b/problems/0242.有效的字母异位词.md
@@ -100,6 +100,9 @@ public:
  */
 class Solution {
     public boolean isAnagram(String s, String t) {
+        if(s.length() != t.length()){
+            return false;
+        }
         int[] record = new int[26];
 
         for (int i = 0; i < s.length(); i++) {


### PR DESCRIPTION
修复两个字符串长度不一样时，当t长度大于s导致s长度之后一直是返回true，例如s = "anagram", t = "nagarama" 时，t的最后一个字符不会参与后续record--操作，程序返回true。