### PR TITLE
优化Python递归时所需要的内存开销和时间消耗。

### DIFF
--- a/problems/二叉树的递归遍历.md
+++ b/problems/二叉树的递归遍历.md
@@ -180,26 +180,34 @@ class Solution {
 
 class Solution:
     def preorderTraversal(self, root: TreeNode) -> List[int]:
-        if not root:
-            return []
-
-        left = self.preorderTraversal(root.left)
-        right = self.preorderTraversal(root.right)
-
-        return  [root.val] + left +  right
+        res = []
+        
+        def dfs(node):
+            if node is None:
+                return
+            
+            res.append(node.val)
+            dfs(node.left)
+            dfs(node.right)
+        
+        return res
 
 ```
 ```python
 # 中序遍历-递归-LC94_二叉树的中序遍历
 class Solution:
     def inorderTraversal(self, root: TreeNode) -> List[int]:
-        if root is None:
-            return []
-
-        left = self.inorderTraversal(root.left)
-        right = self.inorderTraversal(root.right)
-
-        return left + [root.val] + right
+        res = []
+        
+        def dfs(node):
+            if node is None:
+                return
+            
+            dfs(node.left)
+            res.append(node.val)
+            dfs(node.right)
+        
+        return res
 ```
 ```python
 
@@ -207,13 +215,17 @@ class Solution:
 # 后序遍历-递归-LC145_二叉树的后序遍历
 class Solution:
     def postorderTraversal(self, root: TreeNode) -> List[int]:
-        if not root:
-            return []
-
-        left = self.postorderTraversal(root.left)
-        right = self.postorderTraversal(root.right)
-
-        return left + right + [root.val]
+        res = []
+        
+        def dfs(node):
+            if node is None:
+                return
+            
+            dfs(node.left)
+            dfs(node.right)
+            res.append(node.val)
+        
+        return res
 ```
 
 ### Go：


### PR DESCRIPTION
每次连接操作 left + [node.val] + right 都会创建一个新的列表对象，这样在二叉树较大或者深度较深的情况下，会导致大量的内存开销和时间消耗。详细见：
https://leetcode.cn/problems/closest-nodes-queries-in-a-binary-search-tree/solutions/2652707/tong-guo-left-right-hui-xin-jian-lie-bia-f3ha