### PR TITLE
0332.重新安排行程.md：Java解法超时，法三备注有误导性

### DIFF
--- a/problems/0332.重新安排行程.md
+++ b/problems/0332.重新安排行程.md
@@ -261,7 +261,7 @@ for (pair<const string, int>& target : targets[result[result.size() - 1]])
 
 ### Java 
 ```java
-// 方法一，重复的航班只记录次数，减少TreeNode的调整次数，优化时间复杂度
+// 方法一：重复的航班只记录次数而不重复添加，利用TreeMap红黑树排序“到达机场”（TreeMap调用String底层重写的CompareTo）
 // 数据结构：Map<出发机场, Map<到达机场, 航班次数>>
 class Solution {
     private Deque<String> res;
@@ -310,7 +310,7 @@ class Solution {
 ```
 
 ```java
-// 方法二【超时，每次回溯都要遍历一边所有航班，tickets排序过程中有很多冗余计算】
+// 方法二【超时：每次寻找“到达机场”都要遍历一边所有航班；tickets排序过程中有很多冗余计算（并不需要排序所有“到达机场”，只需要排序每个“出发机场”对应的所有“到达机场”）】
 // 数据结构：List<List<出发机场, 到达机场>>（按照字典从小到大排序到达机场）
 class Solution {
     private LinkedList<String> res;
@@ -349,7 +349,7 @@ class Solution {
 ```
 
 ```java
-// 方法三【超时，每次回溯都要增删LinkedList，每次增删都要遍历一边数组。此外，重复路径都要单独考虑，时间复杂度很高】
+// 方法三【超时：每次回溯都要增删LinkedList，每次增删都要遍历一边数组；重复路径要单独考虑，不能复用】
 // 数据结构：Map<出发机场, List<到达机场>>（按照字典从小到大排序到达机场）
 class Solution {
     //key为起点，value是有序的终点的列表

--- a/problems/0332.重新安排行程.md
+++ b/problems/0332.重新安排行程.md
@@ -260,45 +260,9 @@ for (pair<const string, int>& target : targets[result[result.size() - 1]])
 ## 其他语言版本
 
 ### Java 
-
 ```java
-class Solution {
-    private LinkedList<String> res;
-    private LinkedList<String> path = new LinkedList<>();
-
-    public List<String> findItinerary(List<List<String>> tickets) {
-        Collections.sort(tickets, (a, b) -> a.get(1).compareTo(b.get(1)));
-        path.add("JFK");
-        boolean[] used = new boolean[tickets.size()];
-        backTracking((ArrayList) tickets, used);
-        return res;
-    }
-
-    public boolean backTracking(ArrayList<List<String>> tickets, boolean[] used) {
-        if (path.size() == tickets.size() + 1) {
-            res = new LinkedList(path);
-            return true;
-        }
-
-        for (int i = 0; i < tickets.size(); i++) {
-            if (!used[i] && tickets.get(i).get(0).equals(path.getLast())) {
-                path.add(tickets.get(i).get(1));
-                used[i] = true;
-
-                if (backTracking(tickets, used)) {
-                    return true;
-                }
-
-                used[i] = false;
-                path.removeLast();
-            }
-        }
-        return false;
-    }
-}
-```
-
-```java
+// 方法一，重复的航班只记录次数，减少TreeNode的调整次数，优化时间复杂度
+// 数据结构：Map<出发机场, Map<到达机场, 航班次数>>
 class Solution {
     private Deque<String> res;
     private Map<String, Map<String, Integer>> map;
@@ -346,9 +310,47 @@ class Solution {
 ```
 
 ```java
-/*  该方法是对第二个方法的改进，主要变化在于将某点的所有终点变更为链表的形式，优点在于
-        1.添加终点时直接在对应位置添加节点，避免了TreeMap增元素时的频繁调整
-        2.同时每次对终点进行增加删除查找时直接通过下标操作，避免hashMap反复计算hash*/
+// 方法二【超时，每次回溯都要遍历一边所有航班，tickets排序过程中有很多冗余计算】
+// 数据结构：List<List<出发机场, 到达机场>>（按照字典从小到大排序到达机场）
+class Solution {
+    private LinkedList<String> res;
+    private LinkedList<String> path = new LinkedList<>();
+
+    public List<String> findItinerary(List<List<String>> tickets) {
+        Collections.sort(tickets, (a, b) -> a.get(1).compareTo(b.get(1)));
+        path.add("JFK");
+        boolean[] used = new boolean[tickets.size()];
+        backTracking((ArrayList) tickets, used);
+        return res;
+    }
+
+    public boolean backTracking(ArrayList<List<String>> tickets, boolean[] used) {
+        if (path.size() == tickets.size() + 1) {
+            res = new LinkedList(path);
+            return true;
+        }
+
+        for (int i = 0; i < tickets.size(); i++) {
+            if (!used[i] && tickets.get(i).get(0).equals(path.getLast())) {
+                path.add(tickets.get(i).get(1));
+                used[i] = true;
+
+                if (backTracking(tickets, used)) {
+                    return true;
+                }
+
+                used[i] = false;
+                path.removeLast();
+            }
+        }
+        return false;
+    }
+}
+```
+
+```java
+// 方法三【超时，每次回溯都要增删LinkedList，每次增删都要遍历一边数组。此外，重复路径都要单独考虑，时间复杂度很高】
+// 数据结构：Map<出发机场, List<到达机场>>（按照字典从小到大排序到达机场）
 class Solution {
     //key为起点，value是有序的终点的列表
     Map<String, LinkedList<String>> ticketMap = new HashMap<>();


### PR DESCRIPTION
Java 代码实现部分，有两个方法都无法在规定时间内AC，放在文末有误导性。

此外，方法三的备注有误：

1. 添加终点时直接在对应位置添加节点，每次添加都要遍历一次LinkedList，时间复杂度O(n)。而使用TreeNode记录航班次数时间，可以减少相同航班的重复计算，插入的时间复杂度只需O(logn)，调整红黑树结构的耗时并不高。

2. 同时每次对终点进行增加删除查找时直接通过下标操作每次做增删查比较的操作都需要遍历一遍LinkedList，时间复杂度极高。

综上，我对此篇做了修改并提交。

在我看来，这道题不适合放在回溯章节（正如总结部分您所提到的）。在遍历结果的过程中，只会经过一条路径并且这条路径就是正确答案，而不需要对路径回溯。