### PR TITLE
修复二分法 rust 版本左闭右闭示例错误，该错误会导致数组长度为 1 时程序崩溃

### DIFF
--- a/problems/0704.二分查找.md
+++ b/problems/0704.二分查找.md
@@ -509,7 +509,7 @@ func search(nums: [Int], target: Int) -> Int {
 use std::cmp::Ordering;
 impl Solution {
     pub fn search(nums: Vec<i32>, target: i32) -> i32 {
-        let (mut left, mut right) = (0, nums.len()-1);
+        let (mut left, mut right) = (0, nums.len() - 1);
         while left <= right {
             let mid = (right + left) / 2;
             match nums[mid].cmp(&target) {

--- a/problems/0704.二分查找.md
+++ b/problems/0704.二分查找.md
@@ -501,7 +501,29 @@ func search(nums: [Int], target: Int) -> Int {
 
 ### **Rust:**
 
-（版本一）左闭右开区间
+
+
+//（版本一）左闭右闭区间
+
+```rust
+use std::cmp::Ordering;
+impl Solution {
+    pub fn search(nums: Vec<i32>, target: i32) -> i32 {
+        let (mut left, mut right) = (0, nums.len()-1);
+        while left <= right {
+            let mid = (right + left) / 2;
+            match nums[mid].cmp(&target) {
+                Ordering::Less => left = mid + 1,
+                Ordering::Greater => right = mid - 1,
+                Ordering::Equal => return mid as i32,
+            }
+        }
+        -1
+    }
+}
+```
+
+（版本二）左闭右开区间
 
 ```rust
 use std::cmp::Ordering;
@@ -513,26 +535,6 @@ impl Solution {
             match nums[mid].cmp(&target) {
                 Ordering::Less => left = mid + 1,
                 Ordering::Greater => right = mid,
-                Ordering::Equal => return mid as i32,
-            }
-        }
-        -1
-    }
-}
-```
-
-//（版本二）左闭右闭区间
-
-```rust
-use std::cmp::Ordering;
-impl Solution {
-    pub fn search(nums: Vec<i32>, target: i32) -> i32 {
-        let (mut left, mut right) = (0, nums.len());
-        while left <= right {
-            let mid = (right + left) / 2;
-            match nums[mid].cmp(&target) {
-                Ordering::Less => left = mid + 1,
-                Ordering::Greater => right = mid - 1,
                 Ordering::Equal => return mid as i32,
             }
         }


### PR DESCRIPTION
1：修复二分法 rust 版本左闭右闭示例错误，上个作者没有正确区分二分法两种写法的区别，所以导致在该示例中当数组长度为 1 时，会导致程序崩溃。在定义右指针位置时，需要使用 nums.len()-1 ，而不是直接使用 nums.len()
2：将 rust 二分法 两个 示例顺序调整，符合作者讲解顺序，而不是颠倒。