### PR TITLE
修复二分法 Rust 示例错误

### DIFF
--- a/problems/0704.二分查找.md
+++ b/problems/0704.二分查找.md
@@ -501,19 +501,19 @@ func search(nums: [Int], target: Int) -> Int {
 
 ### **Rust:**
 
-（版本一）左闭右开区间
+（版本一）左闭右闭区间
 
 ```rust
 use std::cmp::Ordering;
 impl Solution {
     pub fn search(nums: Vec<i32>, target: i32) -> i32 {
-        let (mut left, mut right) = (0, nums.len());
-        while left < right {
+        let (mut left, mut right) = (0_i32, nums.len() as i32 - 1);
+        while left <= right {
             let mid = (right + left) / 2;
-            match nums[mid].cmp(&target) {
+            match nums[mid as usize].cmp(&target) {
                 Ordering::Less => left = mid + 1,
-                Ordering::Greater => right = mid,
-                Ordering::Equal => return mid as i32,
+                Ordering::Greater => right = mid - 1,
+                Ordering::Equal => return mid,
             }
         }
         -1
@@ -521,19 +521,19 @@ impl Solution {
 }
 ```
 
-//（版本二）左闭右闭区间
+//（版本二）左闭右开区间
 
 ```rust
 use std::cmp::Ordering;
 impl Solution {
     pub fn search(nums: Vec<i32>, target: i32) -> i32 {
-        let (mut left, mut right) = (0, nums.len());
-        while left <= right {
+        let (mut left, mut right) = (0_i32, nums.len() as i32);
+        while left < right {
             let mid = (right + left) / 2;
-            match nums[mid].cmp(&target) {
+            match nums[mid as usize].cmp(&target) {
                 Ordering::Less => left = mid + 1,
-                Ordering::Greater => right = mid - 1,
-                Ordering::Equal => return mid as i32,
+                Ordering::Greater => right = mid,
+                Ordering::Equal => return mid,
             }
         }
         -1


### PR DESCRIPTION
1：修复 二分法 Rust 左闭右闭示例错误，该错误会导致当数组长度为 1 时程序崩溃。
2：优化示例顺序，抱持与作者讲解顺序一致，而不是颠倒
3：修复 二分法 Rust 示例类型错误，该错误导致数组越界错误，原因是指针类型在 Rust 中为usize类型，该类型不可为负数，当数组索引为 0 时，对左右指针进行 0 - 1 运算时会导致运行崩溃。随意需要将左中右指针变为 i32 类型