### PR TITLE
fix 0035_搜索插入位置 Rust 示例错误

### DIFF
--- a/problems/0035.搜索插入位置.md
+++ b/problems/0035.搜索插入位置.md
@@ -313,18 +313,18 @@ func searchInsert(nums []int, target int) int {
 
 ```rust
 impl Solution {
-    pub fn search_insert(nums: Vec<i32>, target: i32) -> i32 {
-        let mut left = 0;
-        let mut right = nums.len();
-        while left < right {
+      pub fn search_insert(nums: Vec<i32>, target: i32) -> i32 {
+        use std::cmp::Ordering::{Equal, Greater, Less};
+        let (mut left, mut right) = (0, nums.len() as i32 - 1);
+        while left <= right {
             let mid = (left + right) / 2;
-            match nums[mid].cmp(&target) {
-                Ordering::Less => left = mid + 1,
-                Ordering::Equal => return ((left + right) / 2) as i32,
-                Ordering::Greater => right = mid,
+            match nums[mid as usize].cmp(&target) {
+                Less => left = mid + 1,
+                Equal => return mid,
+                Greater => right = mid - 1,
             }
         }
-        ((left + right) / 2) as i32
+        right + 1
     }
 }
 ```


### PR DESCRIPTION
fix 0035_搜索插入位置 Rust 示例错误  返回值应为 right+1，而不是 (left+right)/2,该错误会导致 leetcode 测试不通过