### PR TITLE
修改0332.重新安排行程.md 中python解法的markdown格式

### DIFF
--- a/problems/0332.重新安排行程.md
+++ b/problems/0332.重新安排行程.md
@@ -419,7 +419,6 @@ class Solution {
 ```
 
 ### Python
-```
 回溯 使用字典
 ```python	
 class Solution:


### PR DESCRIPTION
0332.重新安排行程.md 中python解法中代码块的markdown格式不对，删除了多余的“```”。