### PR TITLE
fix: 背包理论011rust版本中的逻辑错误

### DIFF
--- a/problems/背包理论基础01背包-1.md
+++ b/problems/背包理论基础01背包-1.md
@@ -716,7 +716,7 @@ pub struct Solution;
 impl Solution {
     pub fn wei_bag_problem1(weight: Vec<usize>, value: Vec<usize>, bag_size: usize) -> usize {
         let mut dp = vec![vec![0; bag_size + 1]; weight.len()];
-        for j in weight[0]..=weight.len() {
+        for j in weight[0]..=bag_size {
             dp[0][j] = value[0];
         }
 


### PR DESCRIPTION
初始化时遍历的范围应该是`weight[0]..=bag_size`，而不是`weight[0]..=weight.len()` 原代码能运行是因为测试用例中的数值刚好不会对结果造成影响，如果将用例中的`bag_size`改为1则运行时会越界访问数组 在线运行示例:  [playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=f887389636209a28fa29d7ba93fbcd59)