### PR TITLE
Update 0236.二叉树的最近公共祖先.md

### DIFF
--- a/problems/0236.二叉树的最近公共祖先.md
+++ b/problems/0236.二叉树的最近公共祖先.md
@@ -454,7 +454,11 @@ impl Solution {
         p: Option<Rc<RefCell<TreeNode>>>,
         q: Option<Rc<RefCell<TreeNode>>>,
     ) -> Option<Rc<RefCell<TreeNode>>> {
-        if root == p || root == q || root.is_none() {
+        if root.is_none() {
+            return root;
+        }
+        if Rc::ptr_eq(root.as_ref().unwrap(), p.as_ref().unwrap()) 
+            || Rc::ptr_eq(root.as_ref().unwrap(), q.as_ref().unwrap()) {
             return root;
         }
         let left = Self::lowest_common_ancestor(


### PR DESCRIPTION
优化Rust版本0236.二叉树的最近公共祖先代码。
原版代码会导致递归比较，而不是比较指针是否相等，已经提交了issue: #2728 