### PR TITLE
优化0151.翻转字符串里的单词的Python版本1解法，删除冗余的strip()函数

### DIFF
--- a/problems/0151.翻转字符串里的单词.md
+++ b/problems/0151.翻转字符串里的单词.md
@@ -4,8 +4,6 @@
 </a>
 <p align="center"><strong><a href="./qita/join.md">参与本项目</a>，贡献其他语言版本的代码，拥抱开源，让更多学习算法的小伙伴们受益！</strong></p>
 
-
-
 > 综合考察字符串操作的好题。
 
 # 151.翻转字符串里的单词
@@ -15,18 +13,18 @@
 给定一个字符串，逐个翻转字符串中的每个单词。
 
 示例 1：  
-输入: "the sky is blue"   
-输出: "blue is sky the"    
+输入: "the sky is blue"  
+输出: "blue is sky the"
 
-示例 2：   
-输入: "  hello world!  "   
-输出: "world! hello"      
-解释: 输入字符串可以在前面或者后面包含多余的空格，但是反转后的字符不能包括。 
+示例 2：  
+输入: "  hello world!  "  
+输出: "world! hello"  
+解释: 输入字符串可以在前面或者后面包含多余的空格，但是反转后的字符不能包括。
 
-示例 3：   
+示例 3：  
 输入: "a good   example"  
-输出: "example good a"     
-解释: 如果两个单词间有多余的空格，将反转后单词间的空格减少到只含一个。  
+输出: "example good a"  
+解释: 如果两个单词间有多余的空格，将反转后单词间的空格减少到只含一个。
 
 ## 算法公开课
 
@@ -36,9 +34,9 @@
 
 **这道题目可以说是综合考察了字符串的多种操作。**
 
-一些同学会使用split库函数，分隔单词，然后定义一个新的string字符串，最后再把单词倒序相加，那么这道题题目就是一道水题了，失去了它的意义。
+一些同学会使用 split 库函数，分隔单词，然后定义一个新的 string 字符串，最后再把单词倒序相加，那么这道题题目就是一道水题了，失去了它的意义。
 
-所以这里我还是提高一下本题的难度：**不要使用辅助空间，空间复杂度要求为O(1)。**
+所以这里我还是提高一下本题的难度：**不要使用辅助空间，空间复杂度要求为 O(1)。**
 
 不能使用辅助空间之后，那么只能在原字符串上下功夫了。
 
@@ -46,18 +44,17 @@
 
 所以解题思路如下：
 
-* 移除多余空格
-* 将整个字符串反转
-* 将每个单词反转
+- 移除多余空格
+- 将整个字符串反转
+- 将每个单词反转
 
-举个例子，源字符串为："the sky is    blue   "
+举个例子，源字符串为："the sky is blue "
 
-* 移除多余空格 : "the sky is blue"
-* 字符串反转："eulb si yks eht"
-* 单词反转："blue is sky the"
+- 移除多余空格 : "the sky is blue"
+- 字符串反转："eulb si yks eht"
+- 单词反转："blue is sky the"
 
 这样我们就完成了翻转字符串里的单词。
-
 
 思路很明确了，我们说一说代码的实现细节，就拿移除多余空格来说，一些同学会上来写如下代码：
 
@@ -79,18 +76,18 @@ void removeExtraSpaces(string& s) {
 }
 ```
 
-逻辑很简单，从前向后遍历，遇到空格了就erase。
+逻辑很简单，从前向后遍历，遇到空格了就 erase。
 
-如果不仔细琢磨一下erase的时间复杂度，还以为以上的代码是O(n)的时间复杂度呢。
+如果不仔细琢磨一下 erase 的时间复杂度，还以为以上的代码是 O(n)的时间复杂度呢。
 
-想一下真正的时间复杂度是多少，一个erase本来就是O(n)的操作。
+想一下真正的时间复杂度是多少，一个 erase 本来就是 O(n)的操作。
 
-erase操作上面还套了一个for循环，那么以上代码移除冗余空格的代码时间复杂度为O(n^2)。
+erase 操作上面还套了一个 for 循环，那么以上代码移除冗余空格的代码时间复杂度为 O(n^2)。
 
-那么使用双指针法来去移除空格，最后resize（重新设置）一下字符串的大小，就可以做到O(n)的时间复杂度。
+那么使用双指针法来去移除空格，最后 resize（重新设置）一下字符串的大小，就可以做到 O(n)的时间复杂度。
 
 ```CPP
-//版本一 
+//版本一
 void removeExtraSpaces(string& s) {
     int slowIndex = 0, fastIndex = 0; // 定义快指针，慢指针
     // 去掉字符串前面的空格
@@ -115,20 +112,19 @@ void removeExtraSpaces(string& s) {
 }
 ```
 
+有的同学可能发现用 erase 来移除空格，在 leetcode 上性能也还行。主要是以下几点；：
 
-有的同学可能发现用erase来移除空格，在leetcode上性能也还行。主要是以下几点；：
+1. leetcode 上的测试集里，字符串的长度不够长，如果足够长，性能差距会非常明显。
+2. leetcode 的测程序耗时不是很准确的。
 
-1. leetcode上的测试集里，字符串的长度不够长，如果足够长，性能差距会非常明显。
-2. leetcode的测程序耗时不是很准确的。
+版本一的代码是一般的思考过程，就是 先移除字符串前的空格，再移除中间的，再移除后面部分。
 
-版本一的代码是一般的思考过程，就是 先移除字符串前的空格，再移除中间的，再移除后面部分。 
-
-不过其实还可以优化，这部分和[27.移除元素](https://programmercarl.com/0027.移除元素.html)的逻辑是一样一样的，本题是移除空格，而 27.移除元素 就是移除元素。 
+不过其实还可以优化，这部分和[27.移除元素](https://programmercarl.com/0027.移除元素.html)的逻辑是一样一样的，本题是移除空格，而 27.移除元素 就是移除元素。
 
 所以代码可以写的很精简，大家可以看 如下 代码 removeExtraSpaces 函数的实现：
 
 ```CPP
-// 版本二 
+// 版本二
 void removeExtraSpaces(string& s) {//去除所有空格并在相邻单词之间添加空格, 快慢指针。
     int slow = 0;   //整体思想参考https://programmercarl.com/0027.移除元素.html
     for (int i = 0; i < s.size(); ++i) { //
@@ -145,9 +141,9 @@ void removeExtraSpaces(string& s) {//去除所有空格并在相邻单词之间�
 
 如果以上代码看不懂，建议先把 [27.移除元素](https://programmercarl.com/0027.移除元素.html)这道题目做了，或者看视频讲解：[数组中移除元素并不容易！LeetCode：27. 移除元素](https://www.bilibili.com/video/BV12A4y1Z7LP) 。
 
-此时我们已经实现了removeExtraSpaces函数来移除冗余空格。
+此时我们已经实现了 removeExtraSpaces 函数来移除冗余空格。
 
-还要实现反转字符串的功能，支持反转字符串子区间，这个实现我们分别在[344.反转字符串](https://programmercarl.com/0344.反转字符串.html)和[541.反转字符串II](https://programmercarl.com/0541.反转字符串II.html)里已经讲过了。
+还要实现反转字符串的功能，支持反转字符串子区间，这个实现我们分别在[344.反转字符串](https://programmercarl.com/0344.反转字符串.html)和[541.反转字符串 II](https://programmercarl.com/0541.反转字符串II.html)里已经讲过了。
 
 代码如下：
 
@@ -199,9 +195,8 @@ public:
 };
 ```
 
-* 时间复杂度: O(n)
-* 空间复杂度: O(1) 或 O(n)，取决于语言中字符串是否可变
-
+- 时间复杂度: O(n)
+- 空间复杂度: O(1) 或 O(n)，取决于语言中字符串是否可变
 
 ## 其他语言版本
 
@@ -291,7 +286,7 @@ class Solution {
             while(i>=0 && initialArr[i] == ' '){i--;}  //跳过空格
             //此时i位置是边界或!=空格，先记录当前索引，之后的while用来确定单词的首字母的位置
             int right = i;
-            while(i>=0 && initialArr[i] != ' '){i--;} 
+            while(i>=0 && initialArr[i] != ' '){i--;}
             //指定区间单词取出(由于i为首字母的前一位，所以这里+1,)，取出的每组末尾都带有一个空格
             for (int j = i+1; j <= right; j++) {
                 newArr[newArrPos++] = initialArr[j];
@@ -399,7 +394,7 @@ class Solution {
         }
         //相当于 c++ 里的 resize()
         char[] newChars = new char[slow];
-        System.arraycopy(chars, 0, newChars, 0, slow); 
+        System.arraycopy(chars, 0, newChars, 0, slow);
         return newChars;
     }
 
@@ -434,21 +429,22 @@ class Solution {
 ```
 
 ### Python:
+
 （版本一）先删除空白，然后整个反转，最后单词反转。
-**因为字符串是不可变类型，所以反转单词的时候，需要将其转换成列表，然后通过join函数再将其转换成列表，所以空间复杂度不是O(1)**
+**因为字符串是不可变类型，所以反转单词的时候，需要将其转换成列表，然后通过 join 函数再将其转换成列表，所以空间复杂度不是 O(1)**
 
 ```Python
 class Solution:
     def reverseWords(self, s: str) -> str:
-        # 删除前后空白
-        s = s.strip()
         # 反转整个字符串
         s = s[::-1]
         # 将字符串拆分为单词，并反转每个单词
+        # split()函数能够自动忽略多余的空白字符
         s = ' '.join(word[::-1] for word in s.split())
         return s
 
 ```
+
 （版本二）使用双指针
 
 ```python
@@ -467,7 +463,9 @@ class Solution:
         # 将列表转换成字符串
         return " ".join(words)
 ```
+
 (版本三) 拆分字符串 + 反转列表
+
 ```python
 class Solution:
     def reverseWords(self, s):
@@ -475,7 +473,9 @@ class Solution:
         words = words[::-1] # 反转单词
         return ' '.join(words) #列表转换成字符串
 ```
+
 (版本四) 将字符串转换为列表后，使用双指针去除空格
+
 ```python
 class Solution:
     def single_reverse(self, s, start: int, end: int):
@@ -514,6 +514,7 @@ class Solution:
 
         return "".join(result)
 ```
+
 ### Go：
 
 版本一：
@@ -538,7 +539,7 @@ func reverseWords(s string) string {
         }
     }
     b = b[0:slow]
-    
+
     // 翻转整个字符串
     reverse(b)
     // 翻转每个单词
@@ -618,8 +619,6 @@ func reverse(b []byte) {
 }
 ```
 
-
-
 ### JavaScript:
 
 ```js
@@ -627,25 +626,25 @@ func reverse(b []byte) {
  * @param {string} s
  * @return {string}
  */
- var reverseWords = function(s) {
-   // 字符串转数组
-   const strArr = Array.from(s);
-   // 移除多余空格
-   removeExtraSpaces(strArr);
-   // 翻转
-   reverse(strArr, 0, strArr.length - 1);
+var reverseWords = function (s) {
+  // 字符串转数组
+  const strArr = Array.from(s);
+  // 移除多余空格
+  removeExtraSpaces(strArr);
+  // 翻转
+  reverse(strArr, 0, strArr.length - 1);
 
-   let start = 0;
+  let start = 0;
 
-   for(let i = 0; i <= strArr.length; i++) {
-     if (strArr[i] === ' ' || i === strArr.length) {
-       // 翻转单词
-       reverse(strArr, start, i - 1);
-       start = i + 1;
-     }
-   }
+  for (let i = 0; i <= strArr.length; i++) {
+    if (strArr[i] === " " || i === strArr.length) {
+      // 翻转单词
+      reverse(strArr, start, i - 1);
+      start = i + 1;
+    }
+  }
 
-   return strArr.join('');
+  return strArr.join("");
 };
 
 // 删除多余空格
@@ -653,9 +652,12 @@ function removeExtraSpaces(strArr) {
   let slowIndex = 0;
   let fastIndex = 0;
 
-  while(fastIndex < strArr.length) {
+  while (fastIndex < strArr.length) {
     // 移除开始位置和重复的空格
-    if (strArr[fastIndex] === ' ' && (fastIndex === 0 || strArr[fastIndex - 1] === ' ')) {
+    if (
+      strArr[fastIndex] === " " &&
+      (fastIndex === 0 || strArr[fastIndex - 1] === " ")
+    ) {
       fastIndex++;
     } else {
       strArr[slowIndex++] = strArr[fastIndex++];
@@ -663,7 +665,7 @@ function removeExtraSpaces(strArr) {
   }
 
   // 移除末尾空格
-  strArr.length = strArr[slowIndex - 1] === ' ' ? slowIndex - 1 : slowIndex;
+  strArr.length = strArr[slowIndex - 1] === " " ? slowIndex - 1 : slowIndex;
 }
 
 // 翻转从 start 到 end 的字符
@@ -671,7 +673,7 @@ function reverse(strArr, start, end) {
   let left = start;
   let right = end;
 
-  while(left < right) {
+  while (left < right) {
     // 交换
     [strArr[left], strArr[right]] = [strArr[right], strArr[left]];
     left++;
@@ -684,59 +686,59 @@ function reverse(strArr, start, end) {
 
 ```typescript
 function reverseWords(s: string): string {
-    /** Utils **/
-    // 删除多余空格, 如'   hello     world   ' => 'hello world'
-    function delExtraSpace(arr: string[]): void {
-        let left: number = 0,
-            right: number = 0,
-            length: number = arr.length;
-        while (right < length && arr[right] === ' ') {
-            right++;
-        }
-        while (right < length) {
-            if (arr[right] === ' ' && arr[right - 1] === ' ') {
-                right++;
-                continue;
-            }
-            arr[left++] = arr[right++];
-        }
-        if (arr[left - 1] === ' ') {
-            arr.length = left - 1;
-        } else {
-            arr.length = left;
-        }
+  /** Utils **/
+  // 删除多余空格, 如'   hello     world   ' => 'hello world'
+  function delExtraSpace(arr: string[]): void {
+    let left: number = 0,
+      right: number = 0,
+      length: number = arr.length;
+    while (right < length && arr[right] === " ") {
+      right++;
     }
-    // 翻转字符串，如：'hello' => 'olleh'
-    function reverseWords(strArr: string[], start: number, end: number) {
-        let temp: string;
-        while (start < end) {
-            temp = strArr[start];
-            strArr[start] = strArr[end];
-            strArr[end] = temp;
-            start++;
-            end--;
-        }
+    while (right < length) {
+      if (arr[right] === " " && arr[right - 1] === " ") {
+        right++;
+        continue;
+      }
+      arr[left++] = arr[right++];
     }
+    if (arr[left - 1] === " ") {
+      arr.length = left - 1;
+    } else {
+      arr.length = left;
+    }
+  }
+  // 翻转字符串，如：'hello' => 'olleh'
+  function reverseWords(strArr: string[], start: number, end: number) {
+    let temp: string;
+    while (start < end) {
+      temp = strArr[start];
+      strArr[start] = strArr[end];
+      strArr[end] = temp;
+      start++;
+      end--;
+    }
+  }
 
-    /** Main code **/
-    let strArr: string[] = s.split('');
-    delExtraSpace(strArr);
-    let length: number = strArr.length;
-    // 翻转整个字符串
-    reverseWords(strArr, 0, length - 1);
-    let start: number = 0,
-        end: number = 0;
-    while (start < length) {
-        end = start;
-        while (strArr[end] !== ' ' && end < length) {
-            end++;
-        }
-        // 翻转单个单词
-        reverseWords(strArr, start, end - 1);
-        start = end + 1;
+  /** Main code **/
+  let strArr: string[] = s.split("");
+  delExtraSpace(strArr);
+  let length: number = strArr.length;
+  // 翻转整个字符串
+  reverseWords(strArr, 0, length - 1);
+  let start: number = 0,
+    end: number = 0;
+  while (start < length) {
+    end = start;
+    while (strArr[end] !== " " && end < length) {
+      end++;
     }
-    return strArr.join('');
-};
+    // 翻转单个单词
+    reverseWords(strArr, start, end - 1);
+    start = end + 1;
+  }
+  return strArr.join("");
+}
 ```
 
 ### Swift:
@@ -772,7 +774,7 @@ func removeSpace(_ s: String) -> [Character] {
         if char != " " || lastArr[lastArr.count - 1] != " "  {
             lastArr.append(char)
         }
-      
+
         left += 1
     }
     return lastArr
@@ -800,7 +802,7 @@ func reverseWord(_ s: inout [Character]) {
             start = i
             entry = true
         }
-      
+
         if entry && s[i] == " " && s[i - 1] != " " {
             end = i - 1
             entry = false
@@ -878,17 +880,17 @@ object Solution {
 
 ```php
 function reverseWords($s) {
-    $this->removeExtraSpaces($s); 
+    $this->removeExtraSpaces($s);
     $this->reverseString($s, 0, strlen($s)-1);
     // 将每个单词反转
-    $start = 0; 
+    $start = 0;
     for ($i = 0; $i <= strlen($s); $i++) {
         // 到达空格或者串尾，说明一个单词结束。进行翻转。
-        if ($i == strlen($s) || $s[$i] == ' ') { 
+        if ($i == strlen($s) || $s[$i] == ' ') {
             // 翻转，注意是左闭右闭 []的翻转。
             $this->reverseString($s, $start, $i-1);
             // +1: 单词与单词直接有个空格
-            $start = $i + 1; 
+            $start = $i + 1;
         }
     }
     return $s;
@@ -896,13 +898,13 @@ function reverseWords($s) {
 
 // 移除多余空格
 function removeExtraSpaces(&$s){
-    $slow = 0;   
+    $slow = 0;
     for ($i = 0; $i < strlen($s); $i++) {
-        if ($s[$i] != ' ') { 
+        if ($s[$i] != ' ') {
             if ($slow != 0){
                 $s[$slow++] = ' ';
-            } 
-            while ($i < strlen($s) && $s[$i] != ' ') { 
+            }
+            while ($i < strlen($s) && $s[$i] != ' ') {
                 $s[$slow++] = $s[$i++];
             }
         }
@@ -922,6 +924,7 @@ function reverseString(&$s, $start, $end) {
     return ;
 }
 ```
+
 ### Rust:
 
 ```Rust
@@ -974,6 +977,7 @@ pub fn remove_extra_spaces(s: &mut Vec<char>) {
     }
 }
 ```
+
 ### C:
 
 ```C
@@ -1019,6 +1023,7 @@ char * reverseWords(char * s){
 ```
 
 ### C#
+
 ```csharp LINQ高级方法
 public string ReverseWords(string s) {
     return string.Join(' ', s.Trim().Split(' ',StringSplitOptions.RemoveEmptyEntries).Reverse());


### PR DESCRIPTION
### 变更内容：
本次PR对151题《翻转字符串里的单词》的Python解法进行了优化。

- 删除了 `strip()` 函数，避免了冗余操作
- 代码已通过所有现有测试用例，功能未受影响

### 优化原因：
通过代码分析，`strip()` 在此场景中多余，因为 `split()` 可以处理空白字符。因此，删除该行代码以减少冗余处理，保持代码简洁。

### 影响：
- 提升了代码的可读性并去除了不必要的处理步骤。
