### PR TITLE
0226翻转二叉树，删除冗余代码

### DIFF
--- a/problems/0226.翻转二叉树.md
+++ b/problems/0226.翻转二叉树.md
@@ -4,21 +4,19 @@
 </a>
 <p align="center"><strong><a href="./qita/join.md">参与本项目</a>，贡献其他语言版本的代码，拥抱开源，让更多学习算法的小伙伴们受益！</strong></p>
 
-
 # 226.翻转二叉树
 
 [力扣题目链接](https://leetcode.cn/problems/invert-binary-tree/)
 
 翻转一棵二叉树。
 
-
 ![226.翻转二叉树](https://code-thinking-1253855093.file.myqcloud.com/pics/20210203192644329.png)
 
-这道题目背后有一个让程序员心酸的故事，听说 Homebrew的作者Max Howell，就是因为没在白板上写出翻转二叉树，最后被Google拒绝了。（真假不做判断，全当一个乐子哈）
+这道题目背后有一个让程序员心酸的故事，听说 Homebrew 的作者 Max Howell，就是因为没在白板上写出翻转二叉树，最后被 Google 拒绝了。（真假不做判断，全当一个乐子哈）
 
 ## 算法公开课
 
-**[《代码随想录》算法视频公开课](https://programmercarl.com/other/gongkaike.html)：[听说一位巨佬面Google被拒了，因为没写出翻转二叉树 | LeetCode：226.翻转二叉树](https://www.bilibili.com/video/BV1sP4y1f7q7)，相信结合视频再看本篇题解，更有助于大家对本题的理解**。
+**[《代码随想录》算法视频公开课](https://programmercarl.com/other/gongkaike.html)：[听说一位巨佬面 Google 被拒了，因为没写出翻转二叉树 | LeetCode：226.翻转二叉树](https://www.bilibili.com/video/BV1sP4y1f7q7)，相信结合视频再看本篇题解，更有助于大家对本题的理解**。
 
 ## 题外话
 
@@ -35,7 +33,6 @@
 这得怎么翻转呢？
 
 如果要从整个树来看，翻转还真的挺复杂，整个树以中间分割线进行翻转，如图：
-
 
 ![226.翻转二叉树1](https://code-thinking-1253855093.file.myqcloud.com/pics/20210203192724351.png)
 
@@ -65,7 +62,7 @@
 
 参数就是要传入节点的指针，不需要其他参数了，通常此时定下来主要参数，如果在写递归的逻辑中发现还需要其他参数的时候，随时补充。
 
-返回值的话其实也不需要，但是题目中给出的要返回root节点的指针，可以直接使用题目定义好的函数，所以就函数的返回类型为`TreeNode*`。
+返回值的话其实也不需要，但是题目中给出的要返回 root 节点的指针，可以直接使用题目定义好的函数，所以就函数的返回类型为`TreeNode*`。
 
 ```cpp
 TreeNode* invertTree(TreeNode* root)
@@ -130,8 +127,8 @@ public:
     }
 };
 ```
-如果这个代码看不懂的话可以再回顾一下[二叉树：听说递归能做的，栈也能做！](https://programmercarl.com/二叉树的迭代遍历.html)。
 
+如果这个代码看不懂的话可以再回顾一下[二叉树：听说递归能做的，栈也能做！](https://programmercarl.com/二叉树的迭代遍历.html)。
 
 我们在[二叉树：前中后序迭代方式的统一写法](https://programmercarl.com/二叉树的统一迭代法.html)中介绍了统一的写法，所以，本题也只需将文中的代码少做修改便可。
 
@@ -189,9 +186,10 @@ public:
     }
 };
 ```
+
 如果对以上代码不理解，或者不清楚二叉树的层序遍历，可以看这篇[二叉树：层序遍历登场！](https://programmercarl.com/0102.二叉树的层序遍历.html)
 
-## 拓展 
+## 拓展
 
 **文中我指的是递归的中序遍历是不行的，因为使用递归的中序遍历，某些节点的左右孩子会翻转两次。**
 
@@ -260,8 +258,8 @@ public:
 
 ## 其他语言版本
 
-
 ### Java:
+
 ```Java
 //DFS递归
 class Solution {
@@ -315,6 +313,7 @@ class Solution {
 ### Python:
 
 递归法：前序遍历：
+
 ```python
 # Definition for a binary tree node.
 # class TreeNode:
@@ -333,6 +332,7 @@ class Solution:
 ```
 
 迭代法：前序遍历：
+
 ```python
 # Definition for a binary tree node.
 # class TreeNode:
@@ -343,20 +343,20 @@ class Solution:
 class Solution:
     def invertTree(self, root: TreeNode) -> TreeNode:
         if not root:
-            return None      
-        stack = [root]        
+            return None
+        stack = [root]
         while stack:
-            node = stack.pop()   
-            node.left, node.right = node.right, node.left                   
+            node = stack.pop()
+            node.left, node.right = node.right, node.left
             if node.left:
                 stack.append(node.left)
             if node.right:
-                stack.append(node.right)  
+                stack.append(node.right)
         return root
 ```
 
-
 递归法：中序遍历：
+
 ```python
 # Definition for a binary tree node.
 # class TreeNode:
@@ -375,6 +375,7 @@ class Solution:
 ```
 
 迭代法：中序遍历：
+
 ```python
 # Definition for a binary tree node.
 # class TreeNode:
@@ -385,20 +386,20 @@ class Solution:
 class Solution:
     def invertTree(self, root: TreeNode) -> TreeNode:
         if not root:
-            return None      
-        stack = [root]        
+            return None
+        stack = [root]
         while stack:
-            node = stack.pop()                   
+            node = stack.pop()
             if node.left:
                 stack.append(node.left)
-            node.left, node.right = node.right, node.left               
+            node.left, node.right = node.right, node.left
             if node.left:
-                stack.append(node.left)       
+                stack.append(node.left)
         return root
 ```
 
-
 递归法：后序遍历：
+
 ```python
 # Definition for a binary tree node.
 # class TreeNode:
@@ -417,6 +418,7 @@ class Solution:
 ```
 
 迭代法：后序遍历：
+
 ```python
 # Definition for a binary tree node.
 # class TreeNode:
@@ -427,24 +429,21 @@ class Solution:
 class Solution:
     def invertTree(self, root: TreeNode) -> TreeNode:
         if not root:
-            return None      
-        stack = [root]        
+            return None
+        stack = [root]
         while stack:
-            node = stack.pop()                   
+            node = stack.pop()
             if node.left:
                 stack.append(node.left)
             if node.right:
-                stack.append(node.right)  
-            node.left, node.right = node.right, node.left               
-     
+                stack.append(node.right)
+            node.left, node.right = node.right, node.left
+
         return root
 ```
 
-
-
-
-
 迭代法：广度优先遍历（层序遍历）：
+
 ```python
 # Definition for a binary tree node.
 # class TreeNode:
@@ -454,30 +453,30 @@ class Solution:
 #         self.right = right
 class Solution:
     def invertTree(self, root: TreeNode) -> TreeNode:
-        if not root: 
+        if not root:
             return None
 
-        queue = collections.deque([root])    
+        queue = collections.deque([root])
         while queue:
-            for i in range(len(queue)):
-                node = queue.popleft()
-                node.left, node.right = node.right, node.left
-                if node.left: queue.append(node.left)
-                if node.right: queue.append(node.right)
-        return root   
+            node = queue.popleft()
+            node.left, node.right = node.right, node.left
+            if node.left: queue.append(node.left)
+            if node.right: queue.append(node.right)
+        return root
 
 ```
 
 ### Go:
 
 递归版本的前序遍历
+
 ```Go
 func invertTree(root *TreeNode) *TreeNode {
     if root == nil {
         return nil
     }
     root.Left, root.Right = root.Right, root.Left    //交换
-    
+
     invertTree(root.Left)
     invertTree(root.Right)
 
@@ -492,11 +491,11 @@ func invertTree(root *TreeNode) *TreeNode {
     if root == nil {
         return root
     }
-    
+
     invertTree(root.Left)     //遍历左节点
     invertTree(root.Right)    //遍历右节点
     root.Left, root.Right = root.Right, root.Left    //交换
-    
+
     return root
 }
 ```
@@ -517,7 +516,7 @@ func invertTree(root *TreeNode) *TreeNode {
         stack = stack[:len(stack)-1]
         node = node.Right
     }
-    
+
     return root
 }
 ```
@@ -545,7 +544,7 @@ func invertTree(root *TreeNode) *TreeNode {
             node = node.Right
         }
     }
-    
+
     return root
 }
 ```
@@ -580,81 +579,86 @@ func invertTree(root *TreeNode) *TreeNode {
 ### JavaScript:
 
 使用递归版本的前序遍历
+
 ```javascript
-var invertTree = function(root) {
-    // 终止条件
-    if (!root) {
-        return null;
-    }
-    // 交换左右节点
-    const rightNode = root.right;
-    root.right = invertTree(root.left);
-    root.left = invertTree(rightNode);
-    return root;
+var invertTree = function (root) {
+  // 终止条件
+  if (!root) {
+    return null;
+  }
+  // 交换左右节点
+  const rightNode = root.right;
+  root.right = invertTree(root.left);
+  root.left = invertTree(rightNode);
+  return root;
 };
 ```
+
 使用迭代版本(统一模板))的前序遍历：
+
 ```javascript
-var invertTree = function(root) {
-    //我们先定义节点交换函数
-    const invertNode = function(root, left, right) {
-        let temp = left;
-        left = right;
-        right = temp;
-        root.left = left;
-        root.right = right;
-    }
-    //使用迭代方法的前序遍历 
-    let stack = [];
-    if(root === null) {
-        return root;
-    }
-    stack.push(root);
-    while(stack.length) {
-        let node = stack.pop();
-        if(node !== null) {
-            //前序遍历顺序中左右  入栈顺序是前序遍历的倒序右左中
-            node.right && stack.push(node.right);
-            node.left && stack.push(node.left);
-            stack.push(node);
-            stack.push(null);
-        } else {
-            node = stack.pop();
-            //节点处理逻辑
-            invertNode(node, node.left, node.right);
-        }
-    }
+var invertTree = function (root) {
+  //我们先定义节点交换函数
+  const invertNode = function (root, left, right) {
+    let temp = left;
+    left = right;
+    right = temp;
+    root.left = left;
+    root.right = right;
+  };
+  //使用迭代方法的前序遍历
+  let stack = [];
+  if (root === null) {
     return root;
+  }
+  stack.push(root);
+  while (stack.length) {
+    let node = stack.pop();
+    if (node !== null) {
+      //前序遍历顺序中左右  入栈顺序是前序遍历的倒序右左中
+      node.right && stack.push(node.right);
+      node.left && stack.push(node.left);
+      stack.push(node);
+      stack.push(null);
+    } else {
+      node = stack.pop();
+      //节点处理逻辑
+      invertNode(node, node.left, node.right);
+    }
+  }
+  return root;
 };
 ```
+
 使用层序遍历：
+
 ```javascript
-var invertTree = function(root) {
-    //我们先定义节点交换函数
-    const invertNode = function(root, left, right) {
-        let temp = left;
-        left = right;
-        right = temp;
-        root.left = left;
-        root.right = right;
-    }
-    //使用层序遍历
-    let queue = [];
-    if(root === null) {
-        return root;
-    } 
-    queue.push(root);
-    while(queue.length) {
-        let length = queue.length;
-        while(length--) {
-            let node = queue.shift();
-            //节点处理逻辑
-            invertNode(node, node.left, node.right);
-            node.left && queue.push(node.left);
-            node.right && queue.push(node.right);
-        }
-    }
+var invertTree = function (root) {
+  //我们先定义节点交换函数
+  const invertNode = function (root, left, right) {
+    let temp = left;
+    left = right;
+    right = temp;
+    root.left = left;
+    root.right = right;
+  };
+  //使用层序遍历
+  let queue = [];
+  if (root === null) {
     return root;
+  }
+  queue.push(root);
+  while (queue.length) {
+    let length = queue.length;
+    while (length--) {
+      let node = queue.shift();
+      //节点处理逻辑
+      invertNode(node, node.left, node.right);
+      node.left && queue.push(node.left);
+      node.right && queue.push(node.right);
+    }
+  }
+  return root;
 };
 ```
 
@@ -665,37 +669,37 @@ var invertTree = function(root) {
 ```typescript
 // 递归法（前序遍历）
 function invertTree(root: TreeNode | null): TreeNode | null {
-    if (root === null) return root;
-    let tempNode: TreeNode | null = root.left;
-    root.left = root.right;
-    root.right = tempNode;
-    invertTree(root.left);
-    invertTree(root.right);
-    return root;
-};
+  if (root === null) return root;
+  let tempNode: TreeNode | null = root.left;
+  root.left = root.right;
+  root.right = tempNode;
+  invertTree(root.left);
+  invertTree(root.right);
+  return root;
+}
 
 // 递归法（后序遍历）
 function invertTree(root: TreeNode | null): TreeNode | null {
-    if (root === null) return root;
-    invertTree(root.left);
-    invertTree(root.right);
-    let tempNode: TreeNode | null = root.left;
-    root.left = root.right;
-    root.right = tempNode;
-    return root;
-};
+  if (root === null) return root;
+  invertTree(root.left);
+  invertTree(root.right);
+  let tempNode: TreeNode | null = root.left;
+  root.left = root.right;
+  root.right = tempNode;
+  return root;
+}
 
 // 递归法（中序遍历）
 function invertTree(root: TreeNode | null): TreeNode | null {
-    if (root === null) return root;
-    invertTree(root.left);
-    let tempNode: TreeNode | null = root.left;
-    root.left = root.right;
-    root.right = tempNode;
-    // 因为左右节点已经进行交换，此时的root.left 是原先的root.right
-    invertTree(root.left);
-    return root;
-};
+  if (root === null) return root;
+  invertTree(root.left);
+  let tempNode: TreeNode | null = root.left;
+  root.left = root.right;
+  root.right = tempNode;
+  // 因为左右节点已经进行交换，此时的root.left 是原先的root.right
+  invertTree(root.left);
+  return root;
+}
 ```
 
 迭代法：
@@ -703,91 +707,88 @@ function invertTree(root: TreeNode | null): TreeNode | null {
 ```typescript
 // 迭代法（栈模拟前序遍历）
 function invertTree(root: TreeNode | null): TreeNode | null {
-    let helperStack: TreeNode[] = [];
-    let curNode: TreeNode,
-        tempNode: TreeNode | null;
-    if (root !== null) helperStack.push(root);
-    while (helperStack.length > 0) {
-        curNode = helperStack.pop()!;
-        // 入栈操作最好在交换节点之前进行，便于理解
-        if (curNode.right) helperStack.push(curNode.right);
-        if (curNode.left) helperStack.push(curNode.left);
-        tempNode = curNode.left;
-        curNode.left = curNode.right;
-        curNode.right = tempNode;
-    }
-    return root;
-};
+  let helperStack: TreeNode[] = [];
+  let curNode: TreeNode, tempNode: TreeNode | null;
+  if (root !== null) helperStack.push(root);
+  while (helperStack.length > 0) {
+    curNode = helperStack.pop()!;
+    // 入栈操作最好在交换节点之前进行，便于理解
+    if (curNode.right) helperStack.push(curNode.right);
+    if (curNode.left) helperStack.push(curNode.left);
+    tempNode = curNode.left;
+    curNode.left = curNode.right;
+    curNode.right = tempNode;
+  }
+  return root;
+}
 
 // 迭代法（栈模拟中序遍历-统一写法形式）
 function invertTree(root: TreeNode | null): TreeNode | null {
-    let helperStack: (TreeNode | null)[] = [];
-    let curNode: TreeNode | null,
-        tempNode: TreeNode | null;
-    if (root !== null) helperStack.push(root);
-    while (helperStack.length > 0) {
-        curNode = helperStack.pop();
-        if (curNode !== null) {
-            if (curNode.right !== null) helperStack.push(curNode.right);
-            helperStack.push(curNode);
-            helperStack.push(null);
-            if (curNode.left !== null) helperStack.push(curNode.left);
-        } else {
-            curNode = helperStack.pop()!;
-            tempNode = curNode.left;
-            curNode.left = curNode.right;
-            curNode.right = tempNode;
-        }
+  let helperStack: (TreeNode | null)[] = [];
+  let curNode: TreeNode | null, tempNode: TreeNode | null;
+  if (root !== null) helperStack.push(root);
+  while (helperStack.length > 0) {
+    curNode = helperStack.pop();
+    if (curNode !== null) {
+      if (curNode.right !== null) helperStack.push(curNode.right);
+      helperStack.push(curNode);
+      helperStack.push(null);
+      if (curNode.left !== null) helperStack.push(curNode.left);
+    } else {
+      curNode = helperStack.pop()!;
+      tempNode = curNode.left;
+      curNode.left = curNode.right;
+      curNode.right = tempNode;
     }
-    return root;
-};
+  }
+  return root;
+}
 
 // 迭代法（栈模拟后序遍历-统一写法形式）
 function invertTree(root: TreeNode | null): TreeNode | null {
-    let helperStack: (TreeNode | null)[] = [];
-    let curNode: TreeNode | null,
-        tempNode: TreeNode | null;
-    if (root !== null) helperStack.push(root);
-    while (helperStack.length > 0) {
-        curNode = helperStack.pop();
-        if (curNode !== null) {
-            helperStack.push(curNode);
-            helperStack.push(null);
-            if (curNode.right !== null) helperStack.push(curNode.right);
-            if (curNode.left !== null) helperStack.push(curNode.left);
-        } else {
-            curNode = helperStack.pop()!;
-            tempNode = curNode.left;
-            curNode.left = curNode.right;
-            curNode.right = tempNode;
-        }
+  let helperStack: (TreeNode | null)[] = [];
+  let curNode: TreeNode | null, tempNode: TreeNode | null;
+  if (root !== null) helperStack.push(root);
+  while (helperStack.length > 0) {
+    curNode = helperStack.pop();
+    if (curNode !== null) {
+      helperStack.push(curNode);
+      helperStack.push(null);
+      if (curNode.right !== null) helperStack.push(curNode.right);
+      if (curNode.left !== null) helperStack.push(curNode.left);
+    } else {
+      curNode = helperStack.pop()!;
+      tempNode = curNode.left;
+      curNode.left = curNode.right;
+      curNode.right = tempNode;
     }
-    return root;
-};
+  }
+  return root;
+}
 
 // 迭代法（队列模拟层序遍历）
 function invertTree(root: TreeNode | null): TreeNode | null {
-    const helperQueue: TreeNode[] = [];
-    let curNode: TreeNode,
-        tempNode: TreeNode | null;
-    if (root !== null) helperQueue.push(root);
-    while (helperQueue.length > 0) {
-        for (let i = 0, length = helperQueue.length; i < length; i++) {
-            curNode = helperQueue.shift()!;
-            tempNode = curNode.left;
-            curNode.left = curNode.right;
-            curNode.right = tempNode;
-            if (curNode.left !== null) helperQueue.push(curNode.left);
-            if (curNode.right !== null) helperQueue.push(curNode.right);
-        }
+  const helperQueue: TreeNode[] = [];
+  let curNode: TreeNode, tempNode: TreeNode | null;
+  if (root !== null) helperQueue.push(root);
+  while (helperQueue.length > 0) {
+    for (let i = 0, length = helperQueue.length; i < length; i++) {
+      curNode = helperQueue.shift()!;
+      tempNode = curNode.left;
+      curNode.left = curNode.right;
+      curNode.right = tempNode;
+      if (curNode.left !== null) helperQueue.push(curNode.left);
+      if (curNode.right !== null) helperQueue.push(curNode.right);
     }
-    return root;
-};
+  }
+  return root;
+}
 ```
 
 ### C:
 
 递归法
+
 ```c
 struct TreeNode* invertTree(struct TreeNode* root){
     if(!root)
@@ -805,6 +806,7 @@ struct TreeNode* invertTree(struct TreeNode* root){
 ```
 
 迭代法：深度优先遍历
+
 ```c
 struct TreeNode* invertTree(struct TreeNode* root){
     if(!root)
@@ -833,6 +835,7 @@ struct TreeNode* invertTree(struct TreeNode* root){
 ```
 
 ### Swift：
+
 ```swift
 // 前序遍历-递归
 func invertTree(_ root: TreeNode?) -> TreeNode? {
@@ -869,7 +872,6 @@ func invertTree1(_ root: TreeNode?) -> TreeNode? {
     return root
 }
 ```
-
 
 深度优先递归。
 
@@ -917,7 +919,9 @@ func invertTree(_ root: TreeNode?) -> TreeNode? {
     return root
 }
 ```
+
 深度优先遍历（前序遍历）:
+
 ```scala
 object Solution {
   def invertTree(root: TreeNode): TreeNode = {
@@ -939,6 +943,7 @@ object Solution {
 ```
 
 广度优先遍历（层序遍历）:
+
 ```scala
 object Solution {
   import scala.collection.mutable
@@ -1000,13 +1005,13 @@ impl Solution {
 public class Solution {
     public TreeNode InvertTree(TreeNode root) {
     if (root == null) return root;
-    
+
     swap(root);
     InvertTree(root.left);
     InvertTree(root.right);
     return root;
     }
-   
+
     public void swap(TreeNode node) {
         TreeNode temp = node.left;
         node.left = node.right;
@@ -1028,9 +1033,7 @@ public TreeNode InvertTree(TreeNode root) {
 }
 ```
 
-
 <p align="center">
 <a href="https://programmercarl.com/other/kstar.html" target="_blank">
   <img src="../pics/网站星球宣传海报.jpg" width="1000"/>
 </a>
-


### PR DESCRIPTION
### 修改说明

在循环 `while queue:` 内遍历二叉树时，`for i in range(len(queue))` 用于确保循环内的操作局限于某一层。但在本题中，仅需对每个节点的两个子节点进行翻转，不需要这个冗余的循环。因此，直接删除该循环。删除后，代码仍然能够正确运行并通过提交。
