### PR TITLE
0226翻转二叉树，删除冗余代码

### DIFF
--- a/problems/0226.翻转二叉树.md
+++ b/problems/0226.翻转二叉树.md
@@ -459,11 +459,10 @@ class Solution:
 
         queue = collections.deque([root])    
         while queue:
-            for i in range(len(queue)):
-                node = queue.popleft()
-                node.left, node.right = node.right, node.left
-                if node.left: queue.append(node.left)
-                if node.right: queue.append(node.right)
+            node = queue.popleft()
+            node.left, node.right = node.right, node.left
+            if node.left: queue.append(node.left)
+            if node.right: queue.append(node.right)
         return root   
 
 ```
@@ -1033,4 +1032,3 @@ public TreeNode InvertTree(TreeNode root) {
 <a href="https://programmercarl.com/other/kstar.html" target="_blank">
   <img src="../pics/网站星球宣传海报.jpg" width="1000"/>
 </a>
-


### PR DESCRIPTION
修改说明
在循环 while queue: 内遍历二叉树时，for i in range(len(queue)) 用于确保循环内的操作局限于某一层。但在本题中，仅需对每个节点的两个子节点进行翻转，不需要这个冗余的循环。因此，直接删除该循环。删除后，代码仍然能够正确运行并通过提交。