### PR TITLE
交换数值部分的int temp改为char temp

### DIFF
--- a/problems/0344.反转字符串.md
+++ b/problems/0344.反转字符串.md
@@ -93,7 +93,7 @@ swap可以有两种实现。
 一种就是常见的交换数值：
 
 ```CPP
-int tmp = s[i];
+char tmp = s[i];
 s[i] = s[j];
 s[j] = tmp;
 


### PR DESCRIPTION
原代码：
int tmp = s[i];
s[i] = s[j];
s[j] = tmp;
s[i]为一个character而不是integer，所以tmp需要修改为char