### PR TITLE
修改 0494.目标和 中Python二维DP版本状态转移判断

### DIFF
--- a/problems/0494.目标和.md
+++ b/problems/0494.目标和.md
@@ -684,7 +684,7 @@ class Solution:
         for i in range(1, len(nums)):
             for j in range(target_sum + 1):
                 dp[i][j] = dp[i - 1][j]  # 不选取当前元素
-                if j >= nums[i - 1]:
+                if j >= nums[i]:
                     dp[i][j] += dp[i - 1][j - nums[i]]  # 选取当前元素
 
         return dp[len(nums)-1][target_sum]  # 返回达到目标和的方案数


### PR DESCRIPTION
判断条件使用了nums[i-1]而不是当前处理的元素nums[i]。这导致在处理第i个元素时错误地检查了前一个元素的值，从而导致状态转移错误。

正确的条件应为j >= nums[i]，以确保当前元素nums[i]可以被选中。

同时建议可以去除初始化时对0元素的操作，在双重循环中当我们碰到0的时候，dp[i][j]会被加2次，这就与2^(0的个数)相对应了。