### PR TITLE
修复0494.目标和题目Python二维DP解法中的错误

### DIFF
--- a/problems/0494.目标和.md
+++ b/problems/0494.目标和.md
@@ -684,7 +684,7 @@ class Solution:
         for i in range(1, len(nums)):
             for j in range(target_sum + 1):
                 dp[i][j] = dp[i - 1][j]  # 不选取当前元素
-                if j >= nums[i - 1]:
+                if j >= nums[i]: #只有j >= 本次遍历元素才可以选取当前元素
                     dp[i][j] += dp[i - 1][j - nums[i]]  # 选取当前元素
 
         return dp[len(nums)-1][target_sum]  # 返回达到目标和的方案数


### PR DESCRIPTION
在遍历过程中，只有j >= 本次遍历元素才可以选取当前元素，原代码中错写为j>=nums[i-1]，修复后变为j>=nums[i]，提交才可以通过leetcode所有用例。