### PR TITLE
Fix 0101.孤岛的总面积.md C++的dfs代码问题

### DIFF
--- a/problems/kamacoder/0101.孤岛的总面积.md
+++ b/problems/kamacoder/0101.孤岛的总面积.md
@@ -112,7 +112,10 @@ int main() {
     int count = 0;
     for (int i = 0; i < n; i++) {
         for (int j = 0; j < m; j++) {
-            if (grid[i][j] == 1) count++;
+            if (grid[i][j] == 1){
+                count++;
+                dfs(grid,i,j);
+            }
         }
     }
     cout << count << endl;


### PR DESCRIPTION
这道题目的意思应该是计算孤岛个数吧，根据题意，
对于
5 6
1 1 0 0 0 0
1 1 0 0 0 0
0 0 1 1 0 0
0 0 0 0 0 1
0 0 0 0 0 0
这个输入，应该输出是1.
但是按照卡哥的代码，输出会是2，问题就出在应该是找到grid[i][j]==1的陆地后，继续进行dfs，而不是直接count++ 我这边是只修改dfs的部分，还没修改bfs 的部分