### PR TITLE
修正卡码网0095.城市间货物运输II中，Python解决SPFA方法求解含有负回路的最短路问题的错误

### DIFF
--- a/problems/kamacoder/0095.城市间货物运输II.md
+++ b/problems/kamacoder/0095.城市间货物运输II.md
@@ -509,8 +509,8 @@ def main():
         for next_node, val in graph[cur_node]:
             if min_dist[next_node] > min_dist[cur_node] + val:
                 min_dist[next_node] = min_dist[cur_node] + val
-                count[next_node] += 1
                 if next_node not in d:
+                    count[next_node] += 1
                     d.append(next_node)
                 if count[next_node] == n:  # 如果某个点松弛了n次，说明有负回路
                     flag = True


### PR DESCRIPTION
修正卡码网0095.城市间货物运输II中，**Python解决SPFA方法求解含有负回路的最短路问题的错误**

原代码(错误的)
```
                count[next_node] += 1
                if next_node not in d:
                      d.append(next_node)
```

在输入例子
```
4 6
1 4 3
1 2 1
1 3 1
3 2 -2
2 4 1
3 4 0
```
会输出`circle`，但正确结果是`0`


纠正代码(可以通过全部例子)
```
                if next_node not in d:
                      count[next_node] += 1
                      d.append(next_node)
```