### PR TITLE
修改problems/kamacoder/0044.开发商购买土地.md中的python优化暴力代码

### DIFF
--- a/problems/kamacoder/0044.开发商购买土地.md
+++ b/problems/kamacoder/0044.开发商购买土地.md
@@ -365,23 +365,19 @@ def main():
     
     count = 0
     # 行切分
-    for i in range(n):
-        
+	# 无需遍历到最后一行，因为切分线始终在行之间
+    for i in range(n - 1):
         for j in range(m):
             count += vec[i][j]
-            # 遍历到行末尾时候开始统计
-            if j == m - 1:
-                result = min(result, abs(sum - 2 * count))
+		result = min(result, abs(sum - 2 * count))
 
     count = 0
     # 列切分
-    for j in range(m):
-        
+	# 无需遍历到最后一列，因为切分线始终在列之间
+    for j in range(m - 1):
         for i in range(n):
             count += vec[i][j]
-            # 遍历到列末尾时候开始统计
-            if i == n - 1:
-                result = min(result, abs(sum - 2 * count))
+		result = min(result, abs(sum - 2 * count))
 
     print(result)
 


### PR DESCRIPTION
无需遍历到最后一行（列），因为切分线始终在行（列）之间。
对于行和列切分那两层循环，时间复杂度从O(2nm)到O((n-1)m+n(m-1))，且取消了if判断，更加通俗易懂，执行效率高点。