### PR TITLE
更改0115.翻转字符串中的单词python语言版本四代码块数组越界错误

### DIFF
--- a/problems/0151.翻转字符串里的单词.md
+++ b/problems/0151.翻转字符串里的单词.md
@@ -492,7 +492,7 @@ class Solution:
             if s[fast] != " ":
                 if len(result) != 0:
                     result += " "
-                while s[fast] != " " and fast < len(s):
+                while fast < len(s) and s[fast] != " ": # 交换顺序会出现数组越界
                     result += s[fast]
                     fast += 1
             else:


### PR DESCRIPTION
0115.翻转字符串中的单词中python语言版本中版本四代码块第19行（整体markdown491行）：应该先判断fast < len(s)再判断s[fast] != " "，否则提交后会出现数组越界错误