### PR TITLE
增加0024：两两交换链表中的节点的python的双指针解法

### DIFF
--- a/problems/0024.两两交换链表中的节点.md
+++ b/problems/0024.两两交换链表中的节点.md
@@ -247,6 +247,42 @@ class Solution:
 
 ```
 
+```python
+# 双指针
+# Definition for singly-linked list.
+# class ListNode:
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution:
+    def swapPairs(self, head: Optional[ListNode]) -> Optional[ListNode]:
+        if head is None or head.next is None:
+            return head
+		
+        # 虚拟头节点
+        dummy_head = ListNode(0, head)
+        # 双指针，cur指向前面的节点，post指向后面的节点，循环从头节点开始
+        cur = head
+        post = dummy_head
+		
+        # 如果遍历完所有节点则循环结束
+        while cur:
+            # 如果是奇数节点，会存在进入循环但是不需要调换的情况，那么就直接返回头节点
+            if not cur.next: 
+                return dummy_head.next
+            # 交换节点
+            post.next = cur.next
+            cur.next = post.next.next
+            post.next.next = cur
+            # 更新指针
+            cur = cur.next
+            post = post.next.next
+        
+        return dummy_head.next
+```
+
+
+
 ### Go：
 
 ```go

--- a/problems/链表总结篇.md
+++ b/problems/链表总结篇.md
@@ -18,7 +18,7 @@
 
 ## 链表经典题目
 
-### 虚拟头结点
+### 虚拟头节点
 
 在[链表：听说用虚拟头节点会方便很多？](https://programmercarl.com/0203.移除链表元素.html)中，我们讲解了链表操作中一个非常重要的技巧：虚拟头节点。
 
@@ -90,7 +90,6 @@
 5. [删除倒数第N个节点](https://programmercarl.com/0019.删除链表的倒数第N个节点.html)
 6. [链表相交](https://programmercarl.com/面试题02.07.链表相交.html)
 7. [有否环形，以及环的入口](https://programmercarl.com/0142.环形链表II.html)
-
 
 
 


### PR DESCRIPTION
增加0024题：两两交换链表的双指针的解法，不需要和原有第二个解法一样使用.next.next.next导致不直观，且简化了循环条件。

链表总结篇.md 虚拟头节点写错了 写成了虚拟头结点